### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/kuma/attachments/feeds.py
+++ b/kuma/attachments/feeds.py
@@ -19,9 +19,9 @@ class AttachmentsFeed(DocumentsFeed):
 
     def item_description(self, item):
         if item.get_previous() is None:
-            return '<p>Created by: %s</p>' % item.creator.username
+            return '<p>Created by: {0!s}</p>'.format(item.creator.username)
         else:
-            return '<p>Edited by %s: %s' % (item.creator.username,
+            return '<p>Edited by {0!s}: {1!s}'.format(item.creator.username,
                                             item.comment)
 
     def item_link(self, item):

--- a/kuma/attachments/models.py
+++ b/kuma/attachments/models.py
@@ -70,8 +70,8 @@ class Attachment(models.Model):
         """
         rev = self.current_revision
         t = select_template([
-            'attachments/attachments/%s.html' % rev.mime_type.replace('/', '_'),
-            'attachments/attachments/%s.html' % rev.mime_type.split('/')[0],
+            'attachments/attachments/{0!s}.html'.format(rev.mime_type.replace('/', '_')),
+            'attachments/attachments/{0!s}.html'.format(rev.mime_type.split('/')[0]),
             'attachments/attachments/generic.html'])
         return t.render({'attachment': rev})
 

--- a/kuma/attachments/tests/test_templates.py
+++ b/kuma/attachments/tests/test_templates.py
@@ -40,14 +40,14 @@ class AttachmentTests(UserTestCase, WikiTestCase):
 
         # now stick it in/on a document
         attachment = Attachment.objects.get(title=title)
-        rev = revision(content='<img src="%s" />' % attachment.get_file_url(),
+        rev = revision(content='<img src="{0!s}" />'.format(attachment.get_file_url()),
                        save=True)
 
         # view it and verify markup is escaped
         response = self.client.get(rev.document.get_edit_url())
         eq_(200, response.status_code)
         doc = pq(response.content)
-        eq_('%s xss' % title,
+        eq_('{0!s} xss'.format(title),
             doc('#page-attachments-table .attachment-name-cell').text())
         ok_('&gt;&lt;img src=x onerror=prompt(navigator.userAgent);&gt;' in
             doc('#page-attachments-table .attachment-name-cell').html())

--- a/kuma/attachments/tests/test_views.py
+++ b/kuma/attachments/tests/test_views.py
@@ -85,7 +85,7 @@ class AttachmentTests(UserTestCase, WikiTestCase):
 
         attachment = Attachment.objects.get(title='Test uploaded file')
         eq_(resp['Location'],
-            'http://testserver%s' % attachment.get_absolute_url())
+            'http://testserver{0!s}'.format(attachment.get_absolute_url()))
 
         rev = attachment.current_revision
         eq_('admin', rev.creator.username)
@@ -134,7 +134,7 @@ class AttachmentTests(UserTestCase, WikiTestCase):
         # Re-fetch because it's been updated.
         attachment = Attachment.objects.get(title='Test editing file')
         eq_(resp['Location'],
-            'http://testserver%s' % attachment.get_absolute_url())
+            'http://testserver{0!s}'.format(attachment.get_absolute_url()))
 
         eq_(2, attachment.revisions.count())
 
@@ -161,7 +161,7 @@ class AttachmentTests(UserTestCase, WikiTestCase):
         url = attachment.get_file_url()
         resp = self.client.get(url, HTTP_HOST=settings.ATTACHMENT_HOST)
         ok_(resp.streaming)
-        eq_('ALLOW-FROM: %s' % settings.DOMAIN, resp['x-frame-options'])
+        eq_('ALLOW-FROM: {0!s}'.format(settings.DOMAIN), resp['x-frame-options'])
         eq_(200, resp.status_code)
         ok_('Last-Modified' in resp)
         ok_('1970' not in resp['Last-Modified'])

--- a/kuma/attachments/utils.py
+++ b/kuma/attachments/utils.py
@@ -37,7 +37,7 @@ def full_attachment_url(attachment_id, filename):
         'attachment_id': attachment_id,
         'filename': filename,
     })
-    return '%s%s%s' % (settings.PROTOCOL, settings.ATTACHMENT_HOST, path)
+    return '{0!s}{1!s}{2!s}'.format(settings.PROTOCOL, settings.ATTACHMENT_HOST, path)
 
 
 def convert_to_http_date(dt):
@@ -71,12 +71,12 @@ def attachment_upload_to(instance, filename):
     # The md5 hash here is of the full timestamp, down to the
     # microsecond, of when the path is generated.
     now = datetime.now()
-    return "attachments/%(date)s/%(id)s/%(md5)s/%(filename)s" % {
+    return "attachments/{date!s}/{id!s}/{md5!s}/{filename!s}".format(**{
         'date': now.strftime('%Y/%m/%d'),
         'id': instance.attachment.id,
         'md5': hashlib.md5(str(now)).hexdigest(),
         'filename': filename
-    }
+    })
 
 
 def attachments_payload(attachments):

--- a/kuma/attachments/views.py
+++ b/kuma/attachments/views.py
@@ -57,7 +57,7 @@ def raw_file(request, attachment_id, filename):
         response = StreamingHttpResponse(rev.file, content_type=rev.mime_type)
         response['Last-Modified'] = convert_to_http_date(rev.created)
         response['Content-Length'] = rev.file.size
-        response['X-Frame-Options'] = 'ALLOW-FROM: %s' % settings.DOMAIN
+        response['X-Frame-Options'] = 'ALLOW-FROM: {0!s}'.format(settings.DOMAIN)
         return response
     else:
         return HttpResponsePermanentRedirect(attachment.get_file_url())

--- a/kuma/authkeys/admin.py
+++ b/kuma/authkeys/admin.py
@@ -6,11 +6,11 @@ from .models import Key, KeyAction
 
 
 def history_link(self):
-    url = '%s?%s' % (reverse('admin:authkeys_keyaction_changelist'),
-                     'key__exact=%s' % (self.id))
+    url = '{0!s}?{1!s}'.format(reverse('admin:authkeys_keyaction_changelist'),
+                     'key__exact={0!s}'.format((self.id)))
     count = self.history.count()
     what = (count == 1) and 'action' or 'actions'
-    return '<a href="%s">%s&nbsp;%s</a>' % (url, count, what)
+    return '<a href="{0!s}">{1!s}&nbsp;{2!s}</a>'.format(url, count, what)
 
 history_link.allow_tags = True
 history_link.short_description = 'Usage history'
@@ -28,7 +28,7 @@ def key_link(self):
     key = self.key
     url = reverse('admin:authkeys_key_change',
                   args=[key.id])
-    return '<a href="%s">%s (#%s)</a>' % (url, key.user, key.id)
+    return '<a href="{0!s}">{1!s} (#{2!s})</a>'.format(url, key.user, key.id)
 
 key_link.allow_tags = True
 key_link.short_description = 'Key'
@@ -36,10 +36,10 @@ key_link.short_description = 'Key'
 
 def content_object_link(self):
     obj = self.content_object
-    url_key = 'admin:%s_%s_change' % (obj._meta.app_label,
+    url_key = 'admin:{0!s}_{1!s}_change'.format(obj._meta.app_label,
                                       obj._meta.model_name)
     url = reverse(url_key, args=[obj.id])
-    return '<a href="%s">%s (#%s)</a>' % (url, self.content_type, obj.pk)
+    return '<a href="{0!s}">{1!s} (#{2!s})</a>'.format(url, self.content_type, obj.pk)
 
 content_object_link.allow_tags = True
 content_object_link.short_description = 'Object'

--- a/kuma/authkeys/models.py
+++ b/kuma/authkeys/models.py
@@ -37,7 +37,7 @@ class Key(models.Model):
     created = models.DateTimeField(auto_now_add=True)
 
     def __unicode__(self):
-        return '<Key %s %s>' % (self.user, self.key)
+        return '<Key {0!s} {1!s}>'.format(self.user, self.key)
 
     def generate_secret(self):
         self.key = generate_key()

--- a/kuma/authkeys/tests/test_decorators.py
+++ b/kuma/authkeys/tests/test_decorators.py
@@ -38,9 +38,9 @@ class KeyDecoratorsTest(TestCase):
             request = HttpRequest()
             request.user = AnonymousUser()
 
-            auth = '%s:%s' % (k, s)
+            auth = '{0!s}:{1!s}'.format(k, s)
             b64_auth = base64.encodestring(auth)
-            request.META['HTTP_AUTHORIZATION'] = 'Basic %s' % b64_auth
+            request.META['HTTP_AUTHORIZATION'] = 'Basic {0!s}'.format(b64_auth)
 
             foo, bar = fake_view(request, 'foo', 'bar')
             eq_('foo', foo)

--- a/kuma/authkeys/tests/test_views.py
+++ b/kuma/authkeys/tests/test_views.py
@@ -96,7 +96,7 @@ class KeyViewsTest(RefetchingUserTestCase):
         page = pq(resp.content)
 
         for ct, key in ((1, self.key1), (1, self.key2), (0, self.key3)):
-            key_row = page.find('.option-list #key-%s' % key.pk)
+            key_row = page.find('.option-list #key-{0!s}'.format(key.pk))
             eq_(ct, key_row.length)
             if ct > 0:
                 eq_(key.description, key_row.find('.description').text())
@@ -105,7 +105,7 @@ class KeyViewsTest(RefetchingUserTestCase):
         # Assemble some sample log lines
         log_lines = []
         for i in range(0, ITEMS_PER_PAGE * 2):
-            log_lines.append(('ping', self.user2, 'Number #%s' % i))
+            log_lines.append(('ping', self.user2, 'Number #{0!s}'.format(i)))
 
         # Record the log lines for this key
         for l in log_lines:
@@ -116,7 +116,7 @@ class KeyViewsTest(RefetchingUserTestCase):
 
         # Iterate through 2 expected pages...
         for qs, offset in (('', 0), ('?page=2', ITEMS_PER_PAGE)):
-            url = '%s%s' % (reverse('authkeys.history', args=(self.key1.pk,),
+            url = '{0!s}{1!s}'.format(reverse('authkeys.history', args=(self.key1.pk,),
                                     locale='en-US'), qs)
             resp = self.client.get(url)
             eq_(200, resp.status_code)
@@ -130,7 +130,7 @@ class KeyViewsTest(RefetchingUserTestCase):
                         row.find('.object').text(),
                         row.find('.notes').text())
                 eq_(expected[0], line[0])
-                ok_('%s' % expected[1] in line[1])
+                ok_('{0!s}'.format(expected[1]) in line[1])
                 eq_(expected[2], line[2])
 
     def test_delete_key(self):

--- a/kuma/core/anonymous.py
+++ b/kuma/core/anonymous.py
@@ -66,8 +66,7 @@ class AnonymousIdentity(object):
             # No getpid() in Jython, for example
             pid = 1
 
-        anon_id = hashlib.md5("%s%s%s%s" %
-                              (randrange(0, MAX_ANONYMOUS_ID),
+        anon_id = hashlib.md5("{0!s}{1!s}{2!s}{3!s}".format(randrange(0, MAX_ANONYMOUS_ID),
                                pid, time.time(), settings.SECRET_KEY)
                               ).hexdigest()
         return anon_id

--- a/kuma/core/decorators.py
+++ b/kuma/core/decorators.py
@@ -38,7 +38,7 @@ def user_access_decorator(redirect_func, redirect_url_func, deny_func=None,
                 # Redirect back here afterwards?
                 if redirect_field:
                     path = urlquote(request.get_full_path())
-                    redirect_url = '%s?%s=%s' % (
+                    redirect_url = '{0!s}?{1!s}={2!s}'.format(
                         redirect_url, redirect_field, path)
 
                 return HttpResponseRedirect(redirect_url)
@@ -99,16 +99,16 @@ def _resolve_lookup((model, lookup, arg_name), view_kwargs):
     """
     value = view_kwargs.get(arg_name)
     if value is None:
-        raise ValueError("Expected kwarg '%s' not found." % arg_name)
+        raise ValueError("Expected kwarg '{0!s}' not found.".format(arg_name))
     if isinstance(model, basestring):
         model_class = get_model(*model.split('.'))
     else:
         model_class = model
     if model_class is None:
-        raise ValueError("The given argument '%s' is not a valid model." %
-                         model)
+        raise ValueError("The given argument '{0!s}' is not a valid model.".format(
+                         model))
     if inspect.isclass(model_class) and not issubclass(model_class, Model):
-        raise ValueError("The argument '%s' needs to be a model." % model)
+        raise ValueError("The argument '{0!s}' needs to be a model.".format(model))
     return get_object_or_404(model_class, **{lookup: value})
 
 

--- a/kuma/core/jobs.py
+++ b/kuma/core/jobs.py
@@ -12,7 +12,7 @@ class KumaJob(Job):
         key = super(KumaJob, self).key(*args, **kwargs)
         if self.version is None:
             return key
-        return '%s#%s' % (key, self.version)
+        return '{0!s}#{1!s}'.format(key, self.version)
 
 
 class IPBanJob(KumaJob):

--- a/kuma/core/management/commands/ihavepower.py
+++ b/kuma/core/management/commands/ihavepower.py
@@ -17,7 +17,7 @@ class Command(BaseCommand):
             user = User.objects.get(username=username)
 
         except User.DoesNotExist:
-            raise CommandError('User %s does not exist.' % username)
+            raise CommandError('User {0!s} does not exist.'.format(username))
 
         if user.is_superuser and user.is_staff:
             raise CommandError('User already has the power!')

--- a/kuma/core/managers.py
+++ b/kuma/core/managers.py
@@ -112,7 +112,7 @@ class _NamespacedTaggableManager(_TaggableManager):
         """
         if (':' in tag.name):
             (ns, name) = tag.name.rsplit(':', 1)
-            return ('%s:' % ns, name)
+            return ('{0!s}:'.format(ns), name)
         else:
             return ('', tag.name)
 
@@ -121,7 +121,7 @@ class _NamespacedTaggableManager(_TaggableManager):
         ns_tags = []
         for t in tags:
             if not t.startswith(namespace):
-                t = '%s%s' % (namespace, t)
+                t = '{0!s}{1!s}'.format(namespace, t)
             ns_tags.append(t)
         return ns_tags
 
@@ -130,7 +130,7 @@ def parse_tag_namespaces(tag_list):
     """Parse a list of tags out into a dict of lists by namespace"""
     namespaces = {}
     for tag in tag_list:
-        ns = (':' in tag) and ('%s:' % tag.rsplit(':', 1)[0]) or ''
+        ns = (':' in tag) and ('{0!s}:'.format(tag.rsplit(':', 1)[0])) or ''
         if ns not in namespaces:
             namespaces[ns] = []
         namespaces[ns].append(tag)

--- a/kuma/core/middleware.py
+++ b/kuma/core/middleware.py
@@ -41,7 +41,7 @@ class LocaleURLMiddleware(object):
             full_path = urllib.quote(full_path.encode('utf-8'))
 
             if query_string:
-                full_path = '%s?%s' % (full_path, query_string)
+                full_path = '{0!s}?{1!s}'.format(full_path, query_string)
 
             response = HttpResponsePermanentRedirect(full_path)
 

--- a/kuma/core/models.py
+++ b/kuma/core/models.py
@@ -18,7 +18,7 @@ class IPBan(models.Model):
         self.save()
 
     def __unicode__(self):
-        return u'%s banned on %s' % (self.ip, self.created)
+        return u'{0!s} banned on {1!s}'.format(self.ip, self.created)
 
 
 @receiver(models.signals.post_save, sender=IPBan)

--- a/kuma/core/tasks.py
+++ b/kuma/core/tasks.py
@@ -31,8 +31,7 @@ def clean_sessions():
     if memcache.add(LOCK_ID, now.strftime('%c'), LOCK_EXPIRE):
         total_count = get_expired_sessions(now).count()
         delete_count = 0
-        logger.info('Deleting the %s of %s oldest expired sessions' %
-                    (chunk_size, total_count))
+        logger.info('Deleting the {0!s} of {1!s} oldest expired sessions'.format(chunk_size, total_count))
         try:
             cursor = connection.cursor()
             delete_count = cursor.execute("""
@@ -43,14 +42,14 @@ def clean_sessions():
                 LIMIT %s;
                 """, [chunk_size])
         finally:
-            logger.info('Deleted %s expired sessions' % delete_count)
+            logger.info('Deleted {0!s} expired sessions'.format(delete_count))
             memcache.delete(LOCK_ID)
             expired_sessions = get_expired_sessions(now)
             if expired_sessions.exists():
                 clean_sessions.apply_async()
     else:
-        logger.error('The clean_sessions task is already running since %s' %
-                     memcache.get(LOCK_ID))
+        logger.error('The clean_sessions task is already running since {0!s}'.format(
+                     memcache.get(LOCK_ID)))
 
 
 @task

--- a/kuma/core/templatetags/jinja_helpers.py
+++ b/kuma/core/templatetags/jinja_helpers.py
@@ -157,7 +157,7 @@ def entity_decode(str):
 
 @library.global_function
 def page_title(title):
-    return u'%s | MDN' % title
+    return u'{0!s} | MDN'.format(title)
 
 
 @library.filter
@@ -314,8 +314,7 @@ def datetimeformat(context, value, format='shortdatetime', output='html'):
 
     if output == 'json':
         return formatted
-    return jinja2.Markup('<time datetime="%s">%s</time>' %
-                         (tzvalue.isoformat(), formatted))
+    return jinja2.Markup('<time datetime="{0!s}">{1!s}</time>'.format(tzvalue.isoformat(), formatted))
 
 
 @library.global_function

--- a/kuma/core/tests/__init__.py
+++ b/kuma/core/tests/__init__.py
@@ -19,7 +19,7 @@ def eq_(first, second, msg=None):
     Note: This should be removed as soon as we no longer use it.
 
     """
-    msg = msg or '%r != %r' % (first, second)
+    msg = msg or '{0!r} != {1!r}'.format(first, second)
     assert first == second, msg
 
 
@@ -29,7 +29,7 @@ def ok_(pred, msg=None):
     Note: This should be removed as soon as we no longer use it.
 
     """
-    msg = msg or '%r != True' % pred
+    msg = msg or '{0!r} != True'.format(pred)
     assert pred, msg
 
 
@@ -97,7 +97,7 @@ class LocalizingMixin(object):
         path = request.get('PATH_INFO', self.defaults.get('PATH_INFO', '/'))
         locale, shortened = split_path(path)
         if not locale:
-            request['PATH_INFO'] = '/%s/%s' % (settings.LANGUAGE_CODE,
+            request['PATH_INFO'] = '/{0!s}/{1!s}'.format(settings.LANGUAGE_CODE,
                                                shortened)
         return super(LocalizingMixin, self).request(**request)
 

--- a/kuma/core/tests/test_helpers.py
+++ b/kuma/core/tests/test_helpers.py
@@ -105,9 +105,9 @@ class TestDateTimeFormat(UserTestCase):
         """Expects shortdatetime, format: Today at {time}."""
         date_today = datetime.today()
         value_returned = unicode(datetimeformat(self.context, date_today))
-        value_expected = 'Today at %s' % format_time(date_today,
+        value_expected = 'Today at {0!s}'.format(format_time(date_today,
                                                      format='short',
-                                                     locale=u'en_US')
+                                                     locale=u'en_US'))
         eq_(pq(value_returned)('time').text(), value_expected)
 
     def test_locale(self):

--- a/kuma/core/tests/test_taggit_extras.py
+++ b/kuma/core/tests/test_taggit_extras.py
@@ -73,4 +73,4 @@ class NamespacedTaggableManagerTest(TestCase):
         tags = ['foo', 'bar', 'baz']
         apple.tags.add_ns('a:', *tags)
 
-        self.assert_tags_equal(apple.tags.all(), ['a:%s' % t for t in tags])
+        self.assert_tags_equal(apple.tags.all(), ['a:{0!s}'.format(t) for t in tags])

--- a/kuma/core/utils.py
+++ b/kuma/core/utils.py
@@ -56,7 +56,7 @@ def paginate(request, queryset, per_page=20):
 
     qsa = urlencode(items)
 
-    paginated.url = u'%s?%s' % (base, qsa)
+    paginated.url = u'{0!s}?{1!s}'.format(base, qsa)
     return paginated
 
 
@@ -118,7 +118,7 @@ class MemcacheLockException(Exception):
 
 class MemcacheLock(object):
     def __init__(self, key, attempts=1, expires=60 * 60 * 3):
-        self.key = 'lock_%s' % key
+        self.key = 'lock_{0!s}'.format(key)
         self.attempts = attempts
         self.expires = expires
         self.cache = memcache
@@ -139,7 +139,7 @@ class MemcacheLock(object):
                 logging.debug('Sleeping for %s while trying to acquire key %s',
                               sleep_time, self.key)
                 time.sleep(sleep_time)
-        raise MemcacheLockException('Could not acquire lock for %s' % self.key)
+        raise MemcacheLockException('Could not acquire lock for {0!s}'.format(self.key))
 
     def release(self):
         self.cache.delete(self.key)
@@ -156,13 +156,13 @@ def memcache_lock(prefix, expires=60 * 60):
             name = '_'.join((prefix, func.__name__) + args)
             lock = MemcacheLock(name, expires=expires)
             if lock.locked():
-                log.warning('Lock %s locked; ignoring call.' % name)
+                log.warning('Lock {0!s} locked; ignoring call.'.format(name))
                 return
             try:
                 # Try to acquire the lock without blocking.
                 lock.acquire()
             except MemcacheLockException:
-                log.warning('Aborting %s; lock acquisition failed.' % name)
+                log.warning('Aborting {0!s}; lock acquisition failed.'.format(name))
                 return
             else:
                 # We have the lock, call the function.

--- a/kuma/core/views.py
+++ b/kuma/core/views.py
@@ -3,7 +3,7 @@ from django.shortcuts import render
 
 def _error_page(request, status):
     """Render error pages with jinja2."""
-    return render(request, '%d.html' % status, status=status)
+    return render(request, '{0:d}.html'.format(status), status=status)
 
 handler403 = lambda request: _error_page(request, 403)
 handler404 = lambda request: _error_page(request, 404)

--- a/kuma/feeder/management/commands/update_feeds.py
+++ b/kuma/feeder/management/commands/update_feeds.py
@@ -48,7 +48,7 @@ class Command(NoArgsCommand):
         for feed in feeds:
             new_entry_count += self.update_feed(feed, **options)
 
-        log.info("Finished run in %f seconds for %d new entries" % (
+        log.info("Finished run in {0:f} seconds for {1:d} new entries".format(
             (time.time() - start), new_entry_count))
 
     def update_feed(self, feed, **options):
@@ -64,7 +64,7 @@ class Command(NoArgsCommand):
             stream = self.fetch_feed(feed)
 
             if stream:
-                log.debug('Processing %s: %s' % (feed.shortname, feed.url))
+                log.debug('Processing {0!s}: {1!s}'.format(feed.shortname, feed.url))
 
                 if 'feed' in stream and 'title' in stream.feed:
                     log.debug('Processing title: %s', stream.feed.title)
@@ -116,7 +116,7 @@ class Command(NoArgsCommand):
             feed.etag = ''
         if feed.last_modified is None:
             feed.last_modified = datetime.datetime(1975, 1, 10)
-        log.debug("feed id=%s feed url=%s etag=%s last_modified=%s" % (
+        log.debug("feed id={0!s} feed url={1!s} etag={2!s} last_modified={3!s}".format(
             feed.shortname, feed.url, feed.etag, str(feed.last_modified)))
         try:
             stream = feedparser.parse(feed.url, etag=feed.etag,
@@ -176,8 +176,7 @@ class Command(NoArgsCommand):
                 log.error('Unable to fetch %s Exception: %s',
                           feed.url, stream.bozo_exception)
                 bozo_msg = stream.bozo_exception
-            feed.disabled_reason = ("Error while reading the feed: %s __ %s" %
-                                    (url_status, bozo_msg))
+            feed.disabled_reason = ("Error while reading the feed: {0!s} __ {1!s}".format(url_status, bozo_msg))
             dirty_feed = True
         else:
             # We've got a live one...
@@ -190,7 +189,7 @@ class Command(NoArgsCommand):
 
         if ('etag' in stream and stream.etag != feed.etag and
                 stream.etag is not None):
-            log.info("New etag %s" % stream.etag)
+            log.info("New etag {0!s}".format(stream.etag))
             feed.etag = stream.etag
             dirty_feed = True
 
@@ -198,13 +197,13 @@ class Command(NoArgsCommand):
                 stream.modified_parsed != feed.last_modified):
             feed.last_modified = time.strftime("%Y-%m-%d %H:%M:%S",
                                                stream.modified_parsed)
-            log.info("New last_modified %s" % feed.last_modified)
+            log.info("New last_modified {0!s}".format(feed.last_modified))
             dirty_feed = True
 
         if dirty_feed:
             try:
                 dirty_feed = False
-                log.debug("Feed %s changed, updating db" % feed)
+                log.debug("Feed {0!s} changed, updating db".format(feed))
                 feed.save()
             except KeyboardInterrupt:
                 raise

--- a/kuma/feeder/models.py
+++ b/kuma/feeder/models.py
@@ -100,7 +100,7 @@ class Entry(models.Model):
         verbose_name_plural = 'Entries'
 
     def __unicode__(self):
-        return '%s: %s' % (self.feed.shortname, self.guid)
+        return '{0!s}: {1!s}'.format(self.feed.shortname, self.guid)
 
     @cached_property
     def parsed(self):

--- a/kuma/humans/models.py
+++ b/kuma/humans/models.py
@@ -27,12 +27,11 @@ class HumansTXT(object):
                                "Contributors on GitHub", "Developer")
 
     def write_to_file(self, humans, target, message, role):
-        target.write("%s \n" % message)
+        target.write("{0!s} \n".format(message))
         for h in humans:
-            target.write("%s: %s \n" %
-                         (role, h.name.encode('ascii', 'ignore')))
+            target.write("{0!s}: {1!s} \n".format(role, h.name.encode('ascii', 'ignore')))
             if h.website is not None:
-                target.write("Website: %s \n" % h.website)
+                target.write("Website: {0!s} \n".format(h.website))
                 target.write('\n')
         target.write('\n')
 

--- a/kuma/humans/tests.py
+++ b/kuma/humans/tests.py
@@ -10,7 +10,7 @@ from kuma.core.tests import ok_
 from .models import HumansTXT, Human
 
 APP_DIR = dirname(__file__)
-CONTRIBUTORS_JSON = "%s/fixtures/contributors.json" % APP_DIR
+CONTRIBUTORS_JSON = "{0!s}/fixtures/contributors.json".format(APP_DIR)
 
 
 class HumansTest(TestCase):
@@ -44,10 +44,10 @@ class HumansTest(TestCase):
         assert human.name == "chengwang"
 
     def test_write_to_file(self):
-        if not isdir("%s/tmp/" % APP_DIR):
-            makedirs("%s/tmp/" % APP_DIR)
+        if not isdir("{0!s}/tmp/".format(APP_DIR)):
+            makedirs("{0!s}/tmp/".format(APP_DIR))
 
-        target = open("%s/tmp/humans.txt" % APP_DIR, 'w')
+        target = open("{0!s}/tmp/humans.txt".format(APP_DIR), 'w')
         human1 = Human()
         human1.name = "joe"
         human1.website = "http://example.com"
@@ -62,12 +62,12 @@ class HumansTest(TestCase):
         ht = HumansTXT()
         ht.write_to_file(humans, target, "Banner Message", "Developer")
 
-        ok_(True, exists("%s/tmp/humans.txt" % APP_DIR))
+        ok_(True, exists("{0!s}/tmp/humans.txt".format(APP_DIR)))
 
         message = False
         name = False
 
-        for line in fileinput.input("%s/tmp/humans.txt" % APP_DIR):
+        for line in fileinput.input("{0!s}/tmp/humans.txt".format(APP_DIR)):
             if line == "Banner Message":
                 message = True
             if line == "joe":

--- a/kuma/search/fields.py
+++ b/kuma/search/fields.py
@@ -40,4 +40,4 @@ class SiteURLField(serializers.ReadOnlyField):
                   for arg in self.kwargs}
         locale = getattr(value, 'locale', settings.LANGUAGE_CODE)
         path = reverse(self.url_name, locale=locale, args=args, kwargs=kwargs)
-        return '%s%s' % (settings.SITE_URL, path)
+        return '{0!s}{1!s}'.format(settings.SITE_URL, path)

--- a/kuma/search/models.py
+++ b/kuma/search/models.py
@@ -64,7 +64,7 @@ class Index(models.Model):
     @cached_property
     def prefixed_name(self):
         "The name to use for the search index in ES"
-        return '%s-%s' % (settings.ES_INDEX_PREFIX, self.name)
+        return '{0!s}-{1!s}'.format(settings.ES_INDEX_PREFIX, self.name)
 
     def populate(self):
         return WikiDocumentType.reindex_all(index=self, chunk_size=500)
@@ -196,7 +196,7 @@ class Filter(models.Model):
 
     def get_absolute_url(self):
         path = reverse('search', locale=settings.LANGUAGE_CODE)
-        return '%s%s?%s=%s' % (settings.SITE_URL, path,
+        return '{0!s}{1!s}?{2!s}={3!s}'.format(settings.SITE_URL, path,
                                self.group.slug, self.slug)
 
 

--- a/kuma/search/tasks.py
+++ b/kuma/search/tasks.py
@@ -77,6 +77,6 @@ def finalize_index(index_pk):
     index.populated = True
     index.save()
 
-    subject = 'Index %s completely populated' % index.prefixed_name
+    subject = 'Index {0!s} completely populated'.format(index.prefixed_name)
     message = 'You may want to promote it now via the admin interface.'
     mail_admins(subject=subject, message=message)

--- a/kuma/search/tests/__init__.py
+++ b/kuma/search/tests/__init__.py
@@ -45,7 +45,7 @@ class ElasticTestCase(UserTestCase):
             return
 
         cls._old_es_index_prefix = settings.ES_INDEX_PREFIX
-        settings.ES_INDEX_PREFIX = 'test-%s' % settings.ES_INDEX_PREFIX
+        settings.ES_INDEX_PREFIX = 'test-{0!s}'.format(settings.ES_INDEX_PREFIX)
         cls._old_es_live_index = settings.ES_LIVE_INDEX
         settings.ES_LIVE_INDEX = True
 

--- a/kuma/search/tests/test_indexes.py
+++ b/kuma/search/tests/test_indexes.py
@@ -20,7 +20,7 @@ class TestIndexes(ElasticTestCase):
 
     def test_get_current(self):
         eq_(Index.objects.get_current().prefixed_name,
-            '%s-main_index' % settings.ES_INDEX_PREFIX)
+            '{0!s}-main_index'.format(settings.ES_INDEX_PREFIX))
 
     def _reload(self, index):
         return Index.objects.get(pk=index.pk)

--- a/kuma/search/tests/test_views.py
+++ b/kuma/search/tests/test_views.py
@@ -223,8 +223,8 @@ class ViewTests(ElasticTestCase):
         response = self.client.get('/en-US/search')
         eq_(response.status_code, 200)
         self.assertContains(response,
-                            ('Search index: %s' %
-                             Index.objects.get_current().name))
+                            ('Search index: {0!s}'.format(
+                             Index.objects.get_current().name)))
 
     def test_score(self):
         response = self.client.get('/en-US/search.json')

--- a/kuma/search/utils.py
+++ b/kuma/search/utils.py
@@ -80,11 +80,11 @@ def search_exception_handler(exc, context):
             # FIXME: This really should return a 503 error instead but Zeus
             # doesn't let that through and displays a generic error page in that
             # case which we don't want here
-            log.error('Elasticsearch exception: %s' % exc)
+            log.error('Elasticsearch exception: {0!s}'.format(exc))
             return Response({'detail': SEARCH_DOWN_DETAIL},
                             status=status.HTTP_200_OK)
         elif isinstance(exc, UnicodeDecodeError):
-            log.error('UnicodeDecodeError exception: %s' % exc)
+            log.error('UnicodeDecodeError exception: {0!s}'.format(exc))
             return Response({'detail': SEARCH_ERROR_DETAIL},
                             status=status.HTTP_404_NOT_FOUND)
 

--- a/kuma/spam/akismet.py
+++ b/kuma/spam/akismet.py
@@ -21,8 +21,7 @@ class AkismetError(Exception):
         self.debug_help = debug_help
 
     def __str__(self):
-        return ('%s response, debug help: %s, full response: %s' %
-                (self.status_code, self.debug_help, self.response.text))
+        return ('{0!s} response, debug help: {1!s}, full response: {2!s}'.format(self.status_code, self.debug_help, self.response.text))
 
 
 class Akismet(object):
@@ -76,7 +75,7 @@ class Akismet(object):
 
     @property
     def url(self):
-        return 'https://%s.rest.akismet.com/1.1/' % self.key
+        return 'https://{0!s}.rest.akismet.com/1.1/'.format(self.key)
 
     def send(self, method, **payload):
         # blog is the only parameter required by all API endpoints

--- a/kuma/spam/forms.py
+++ b/kuma/spam/forms.py
@@ -113,7 +113,7 @@ class AkismetSubmissionFormMixin(AkismetFormMixin):
         """"
         Get the submission funciton and call it with the parameters.
         """
-        submission_function = 'submit_%s' % self.akismet_submission_type()
+        submission_function = 'submit_{0!s}'.format(self.akismet_submission_type())
         try:
             getattr(self.akismet_client, submission_function)(**parameters)
         except akismet.AkismetError:

--- a/kuma/urls.py
+++ b/kuma/urls.py
@@ -59,7 +59,7 @@ urlpatterns = [
 if settings.SERVE_MEDIA:
     media_url = settings.MEDIA_URL.lstrip('/').rstrip('/')
     urlpatterns += [
-        url(r'^%s/(?P<path>.*)$' % media_url,
+        url(r'^{0!s}/(?P<path>.*)$'.format(media_url),
             serve,
             {'document_root': settings.MEDIA_ROOT}),
     ]

--- a/kuma/users/adapters.py
+++ b/kuma/users/adapters.py
@@ -50,7 +50,7 @@ class KumaAccountAdapter(DefaultAccountAdapter):
         return username
 
     def message_templates(self, *names):
-        return tuple('messages/%s.txt' % name for name in names)
+        return tuple('messages/{0!s}.txt'.format(name) for name in names)
 
     def add_message(self, request, level, message_template,
                     message_context={}, extra_tags='', *args, **kwargs):

--- a/kuma/users/admin.py
+++ b/kuma/users/admin.py
@@ -37,16 +37,16 @@ class UserAdmin(BaseUserAdmin):
         link = urlparams(reverse('dashboards.revisions'),
                          user=obj.username)
         count = obj.created_revisions.count()
-        return ('<a href="%(link)s"><strong>%(count)s</strong></a>' %
-                {'link': link, 'count': count})
+        return ('<a href="{link!s}"><strong>{count!s}</strong></a>'.format(**
+                {'link': link, 'count': count}))
 
     revisions.allow_tags = True
 
     def website(self, obj):
         """HTML link to user's website"""
         if obj.website_url:
-            return ('<a href="%(url)s"><strong>%(url)s</strong></a>' %
-                    {'url': escape(obj.website_url)})
+            return ('<a href="{url!s}"><strong>{url!s}</strong></a>'.format(**
+                    {'url': escape(obj.website_url)}))
         return ""
 
     website.allow_tags = True

--- a/kuma/users/backends.py
+++ b/kuma/users/backends.py
@@ -17,7 +17,7 @@ class Sha256Hasher(BasePasswordHasher):
         assert password
         assert salt and '$' not in salt
         hash = self.digest(salt + password).hexdigest()
-        return "%s$%s$%s" % (self.algorithm, salt, hash)
+        return "{0!s}${1!s}${2!s}".format(self.algorithm, salt, hash)
 
     def verify(self, password, encoded):
         algorithm, salt, hash = encoded.split('$', 2)

--- a/kuma/users/jobs.py
+++ b/kuma/users/jobs.py
@@ -18,8 +18,8 @@ class UserGravatarURLJob(KumaJob):
                     'http://www.gravatar.com')
         email_hash = hashlib.md5(email.lower().encode('utf8'))
         params = urllib.urlencode({'s': size, 'd': default, 'r': rating})
-        return '%(base_url)s/avatar/%(hash)s?%(params)s' % {
+        return '{base_url!s}/avatar/{hash!s}?{params!s}'.format(**{
             'base_url': base_url,
             'hash': email_hash.hexdigest(),
             'params': params,
-        }
+        })

--- a/kuma/users/providers/persona/views.py
+++ b/kuma/users/providers/persona/views.py
@@ -41,7 +41,7 @@ def persona_login(request):
     querystring = QueryDict('', mutable=True)
     for param in ('next', 'process'):
         querystring[param] = request.POST.get(param, '')
-    return redirect('%s?%s' % (reverse('persona_complete'),
+    return redirect('{0!s}?{1!s}'.format(reverse('persona_complete'),
                                querystring.urlencode('/')))
 
 

--- a/kuma/users/templatetags/jinja_helpers.py
+++ b/kuma/users/templatetags/jinja_helpers.py
@@ -41,7 +41,7 @@ def ban_link(context, ban_user, banner_user):
                     '<i aria-hidden="true" class="icon-ban"></i></a>'
                     % (url, title, ugettext('Banned')))
         else:
-            url = '%s?user=%s&by=%s' % (
+            url = '{0!s}?user={1!s}&by={2!s}'.format(
                 reverse('admin:users_userban_add'), ban_user.id,
                 banner_user.id)
             link = ('<a href="%s" class="button negative ban-link">%s'
@@ -64,12 +64,12 @@ def admin_link(user):
 @library.filter
 def public_email(email):
     """Email address -> publicly displayable email."""
-    return Markup('<span class="email">%s</span>' % unicode_to_html(email))
+    return Markup('<span class="email">{0!s}</span>'.format(unicode_to_html(email)))
 
 
 def unicode_to_html(text):
     """Turns all unicode into html entities, e.g. &#69; -> E."""
-    return ''.join([u'&#%s;' % ord(i) for i in text])
+    return ''.join([u'&#{0!s};'.format(ord(i)) for i in text])
 
 
 @library.global_function

--- a/kuma/users/tests/__init__.py
+++ b/kuma/users/tests/__init__.py
@@ -37,7 +37,7 @@ def email(save=False, **kwargs):
     if 'user' not in kwargs:
         kwargs['user'] = user(save=True)
     if 'email' not in kwargs:
-        kwargs['email'] = '%s@%s.com' % (get_random_string(),
+        kwargs['email'] = '{0!s}@{1!s}.com'.format(get_random_string(),
                                          get_random_string())
     email = EmailAddress(**kwargs)
     if save:

--- a/kuma/users/tests/test_forms.py
+++ b/kuma/users/tests/test_forms.py
@@ -99,11 +99,11 @@ class TestUserEditForm(KumaTestCase):
         edit_user = user(save=True)
         for proto, expected_valid in protos:
             for name, site in sites:
-                url = '%s%s' % (proto, site)
+                url = '{0!s}{1!s}'.format(proto, site)
                 data = {
                     'username': edit_user.username,
                     'email': 'lorchard@mozilla.com',
-                    '%s_url' % name: url,
+                    '{0!s}_url'.format(name): url,
                 }
                 form = UserEditForm(data, instance=edit_user)
                 result_valid = form.is_valid()

--- a/kuma/users/tests/test_helpers.py
+++ b/kuma/users/tests/test_helpers.py
@@ -17,7 +17,7 @@ class HelperTestCase(UserTestCase):
     def test_default_gravatar(self):
         d_param = urllib.urlencode({'d': settings.DEFAULT_AVATAR})
         ok_(d_param in gravatar_url(self.u.email),
-            "Bad default avatar: %s" % gravatar_url(self.u.email))
+            "Bad default avatar: {0!s}".format(gravatar_url(self.u.email)))
 
     def test_gravatar_url(self):
         self.u.email = 'test@test.com'

--- a/kuma/users/tests/test_templates.py
+++ b/kuma/users/tests/test_templates.py
@@ -263,8 +263,8 @@ class AllauthPersonaTestCase(UserTestCase):
                                locale=settings.WIKI_DEFAULT_LANGUAGE)
         response = self.client.get(all_docs_url, follow=True)
         parsed = pq(response.content)
-        request_info = '{"siteName": "%(siteName)s", "siteLogo": "%(siteLogo)s"}' % \
-                       settings.SOCIALACCOUNT_PROVIDERS['persona']['REQUEST_PARAMETERS']
+        request_info = '{{"siteName": "{siteName!s}", "siteLogo": "{siteLogo!s}"}}'.format(** \
+                       settings.SOCIALACCOUNT_PROVIDERS['persona']['REQUEST_PARAMETERS'])
         stub_attrs = (
             ('data-csrf-token-url', reverse('persona_csrf_token')),
             ('data-request', request_info),

--- a/kuma/users/tests/test_views.py
+++ b/kuma/users/tests/test_views.py
@@ -169,8 +169,8 @@ class UserViewsTest(UserTestCase):
         """A non-numeric page number should not cause an error"""
         testuser = self.user_model.objects.get(username='testuser')
 
-        url = '%s?page=asdf' % reverse('users.user_detail',
-                                       args=(testuser.username,))
+        url = '{0!s}?page=asdf'.format(reverse('users.user_detail',
+                                       args=(testuser.username,)))
 
         try:
             self.client.get(url, follow=True)
@@ -304,7 +304,7 @@ class UserViewsTest(UserTestCase):
         form = self._get_current_form_field_values(doc)
 
         # Fill out the form with websites.
-        form.update(dict(('user-%s_url' % k, v)
+        form.update(dict(('user-{0!s}_url'.format(k), v)
                          for k, v in test_sites.items()))
 
         # Submit the form, verify redirect to user detail
@@ -316,7 +316,7 @@ class UserViewsTest(UserTestCase):
 
         # Verify the websites are saved in the user.
         for site, url in test_sites.items():
-            url_attr_name = '%s_url' % site
+            url_attr_name = '{0!s}_url'.format(site)
             eq_(getattr(testuser, url_attr_name), url)
 
         # Verify the saved websites appear in the editing form
@@ -324,7 +324,7 @@ class UserViewsTest(UserTestCase):
         response = self.client.get(url, follow=True)
         doc = pq(response.content)
         for k, v in test_sites.items():
-            eq_(v, doc.find('#user-edit *[name="user-%s_url"]' % k).val())
+            eq_(v, doc.find('#user-edit *[name="user-{0!s}_url"]'.format(k)).val())
 
         # Come up with some bad sites, either invalid URL or bad URL prefix
         bad_sites = {
@@ -332,7 +332,7 @@ class UserViewsTest(UserTestCase):
             'twitter': 'http://facebook.com/lmorchard',
             'stackoverflow': 'http://overqueueblah.com/users/lmorchard',
         }
-        form.update(dict(('user-%s_url' % k, v)
+        form.update(dict(('user-{0!s}_url'.format(k), v)
                          for k, v in bad_sites.items()))
 
         # Submit the form, verify errors for all of the bad sites
@@ -447,7 +447,7 @@ class UserViewsTest(UserTestCase):
             # if label is localized it's a lazy proxy object
             ok_(not isinstance(
                 response.context['user_form'].fields[field].label, basestring),
-                'Field %s is a string!' % field)
+                'Field {0!s} is a string!'.format(field))
 
     def test_bug_1174804(self):
         """Test that the newsletter form field are safely rendered"""
@@ -577,7 +577,7 @@ class AllauthPersonaTestCase(UserTestCase):
             response = self.client.post(reverse('persona_login'),
                                         data={'next': doc_url},
                                         follow=True)
-            ok_(('http://testserver%s' % doc_url, 302) in response.redirect_chain)
+            ok_(('http://testserver{0!s}'.format(doc_url), 302) in response.redirect_chain)
 
     def test_persona_signup_create_django_user(self):
         """
@@ -711,10 +711,10 @@ class KumaGitHubTests(UserTestCase):
         rt = ''
         if with_refresh_token:
             rt = ',"refresh_token": "testrf"'
-        return """{
+        return """{{
             "uid":"weibo",
             "access_token":"testac"
-            %s }""" % rt
+            {0!s} }}""".format(rt)
 
     def setUp(self):
         self.signup_url = reverse('socialaccount_signup',

--- a/kuma/wiki/admin.py
+++ b/kuma/wiki/admin.py
@@ -20,9 +20,9 @@ from .models import (Document, DocumentSpamAttempt, DocumentTag, DocumentZone,
 
 
 def dump_selected_documents(self, request, queryset):
-    filename = "documents_%s.json" % (datetime.now().isoformat(),)
+    filename = "documents_{0!s}.json".format(datetime.now().isoformat())
     response = HttpResponse(content_type="text/plain")
-    response['Content-Disposition'] = 'attachment; filename=%s' % filename
+    response['Content-Disposition'] = 'attachment; filename={0!s}'.format(filename)
     Document.objects.dump_json(queryset, response)
     return response
 
@@ -58,7 +58,7 @@ def purge_view(request):
             for doc in to_purge:
                 doc.purge()
                 purged += 1
-            messages.info(request, "%s document(s) were purged." % purged)
+            messages.info(request, "{0!s} document(s) were purged.".format(purged))
         return HttpResponseRedirect('/admin/wiki/document/')
     return TemplateResponse(request,
                             'admin/wiki/purge_documents.html',
@@ -73,16 +73,16 @@ restore_documents.short_description = "Restore deleted documents"
 
 def enable_deferred_rendering_for_documents(self, request, queryset):
     queryset.update(defer_rendering=True)
-    self.message_user(request, 'Enabled deferred rendering for %s Documents' %
-                               queryset.count())
+    self.message_user(request, 'Enabled deferred rendering for {0!s} Documents'.format(
+                               queryset.count()))
 enable_deferred_rendering_for_documents.short_description = (
     "Enable deferred rendering for selected documents")
 
 
 def disable_deferred_rendering_for_documents(self, request, queryset):
     queryset.update(defer_rendering=False)
-    self.message_user(request, 'Disabled deferred rendering for %s Documents' %
-                               queryset.count())
+    self.message_user(request, 'Disabled deferred rendering for {0!s} Documents'.format(
+                               queryset.count()))
 disable_deferred_rendering_for_documents.short_description = (
     "Disable deferred rendering for selected documents")
 
@@ -119,13 +119,13 @@ resave_current_revision.short_description = (
 
 def related_revisions_link(obj):
     """HTML link to related revisions for admin change list"""
-    link = '%s?%s' % (
+    link = '{0!s}?{1!s}'.format(
         reverse('admin:wiki_revision_changelist', args=[]),
-        'document__exact=%s' % (obj.id)
+        'document__exact={0!s}'.format((obj.id))
     )
     count = obj.revisions.count()
     what = (count == 1) and 'revision' or 'revisions'
-    return '<a href="%s">%s&nbsp;%s</a>' % (link, count, what)
+    return '<a href="{0!s}">{1!s}&nbsp;{2!s}</a>'.format(link, count, what)
 
 related_revisions_link.allow_tags = True
 related_revisions_link.short_description = "All Revisions"
@@ -137,7 +137,7 @@ def current_revision_link(obj):
         return "None"
     rev = obj.current_revision
     rev_url = reverse('admin:wiki_revision_change', args=[rev.id])
-    return '<a href="%s">Current&nbsp;Revision&nbsp;(#%s)</a>' % (rev_url, rev.id)
+    return '<a href="{0!s}">Current&nbsp;Revision&nbsp;(#{1!s})</a>'.format(rev_url, rev.id)
 
 current_revision_link.allow_tags = True
 current_revision_link.short_description = "Current Revision"
@@ -148,7 +148,7 @@ def parent_document_link(obj):
     if not obj.parent:
         return ''
     url = reverse('admin:wiki_document_change', args=[obj.parent.id])
-    return '<a href="%s">Translated&nbsp;from&nbsp;(#%s)</a>' % (url, obj.parent.id)
+    return '<a href="{0!s}">Translated&nbsp;from&nbsp;(#{1!s})</a>'.format(url, obj.parent.id)
 
 parent_document_link.allow_tags = True
 parent_document_link.short_description = "Translation Parent"
@@ -160,7 +160,7 @@ def topic_parent_document_link(obj):
         return ''
     url = reverse('admin:wiki_document_change',
                   args=[obj.parent_topic.id])
-    return '<a href="%s">Topic&nbsp;Parent&nbsp;(#%s)</a>' % (url, obj.parent_topic.id)
+    return '<a href="{0!s}">Topic&nbsp;Parent&nbsp;(#{1!s})</a>'.format(url, obj.parent_topic.id)
 
 topic_parent_document_link.allow_tags = True
 topic_parent_document_link.short_description = "Parent Document"
@@ -171,12 +171,12 @@ def topic_children_documents_link(obj):
     count = obj.children.count()
     if not count:
         return ''
-    link = '%s?%s' % (
+    link = '{0!s}?{1!s}'.format(
         reverse('admin:wiki_document_changelist', args=[]),
-        'parent_topic__exact=%s' % (obj.id)
+        'parent_topic__exact={0!s}'.format((obj.id))
     )
     what = (count == 1) and 'child' or 'children'
-    return '<a href="%s">%s&nbsp;%s</a>' % (link, count, what)
+    return '<a href="{0!s}">{1!s}&nbsp;{2!s}</a>'.format(link, count, what)
 
 topic_children_documents_link.allow_tags = True
 topic_children_documents_link.short_description = "Child Documents"
@@ -189,12 +189,12 @@ def topic_sibling_documents_link(obj):
     count = obj.parent_topic.children.count()
     if not count:
         return ''
-    link = '%s?%s' % (
+    link = '{0!s}?{1!s}'.format(
         reverse('admin:wiki_document_changelist', args=[]),
-        'parent_topic__exact=%s' % (obj.parent_topic.id)
+        'parent_topic__exact={0!s}'.format((obj.parent_topic.id))
     )
     what = (count == 1) and 'sibling' or 'siblings'
-    return '<a href="%s">%s&nbsp;%s</a>' % (link, count, what)
+    return '<a href="{0!s}">{1!s}&nbsp;{2!s}</a>'.format(link, count, what)
 
 topic_sibling_documents_link.allow_tags = True
 topic_sibling_documents_link.short_description = "Sibling Documents"
@@ -214,7 +214,7 @@ document_link.short_description = "Public"
 def combine_funcs(obj, funcs):
     """Combine several field functions into one block of lines"""
     out = (x(obj) for x in funcs)
-    return '<ul>%s</ul>' % ''.join('<li>%s</li>' % x for x in out if x)
+    return '<ul>{0!s}</ul>'.format(''.join('<li>{0!s}</li>'.format(x) for x in out if x))
 
 
 def document_nav_links(obj):
@@ -243,13 +243,13 @@ revision_links.short_description = "Revisions"
 
 def rendering_info(obj):
     """Combine the rendering times into one block"""
-    return '<ul>%s</ul>' % ''.join('<li>%s</li>' % (x % y) for x, y in (
+    return '<ul>{0!s}</ul>'.format(''.join('<li>{0!s}</li>'.format((x % y)) for x, y in (
         ('<img src="%s/admin/img/admin/icon-yes.gif" alt="%s"> '
          'Deferred rendering', (settings.STATIC_URL, obj.defer_rendering)),
         ('%s (last)', obj.last_rendered_at),
         ('%s (started)', obj.render_started_at),
         ('%s (scheduled)', obj.render_scheduled_at),
-    ) if y)
+    ) if y))
 
 rendering_info.allow_tags = True
 rendering_info.short_description = 'Rendering'
@@ -366,8 +366,7 @@ class RevisionAkismetSubmissionAdmin(DisabledDeletionMixin, admin.ModelAdmin):
         """Admin link to the revision"""
         admin_link = reverse('admin:wiki_revision_change',
                              args=[obj.revision.id])
-        return ('<a target="_blank" href="%s">%s</a>' %
-                (admin_link, escape(obj.revision)))
+        return ('<a target="_blank" href="{0!s}">{1!s}</a>'.format(admin_link, escape(obj.revision)))
     revision_with_link.allow_tags = True
     revision_with_link.short_description = "Revision"
 

--- a/kuma/wiki/apps.py
+++ b/kuma/wiki/apps.py
@@ -135,9 +135,9 @@ class WikiConfig(AppConfig):
     def on_document_spam_attempt_save(self, sender, instance, **kwargs):
         subject = u'[MDN] Wiki spam attempt recorded'
         if instance.document:
-            subject = u'%s for document %s' % (subject, instance.document)
+            subject = u'{0!s} for document {1!s}'.format(subject, instance.document)
         elif instance.title:
-            subject = u'%s with title %s' % (subject, instance.title)
+            subject = u'{0!s} with title {1!s}'.format(subject, instance.title)
         body = render_to_string('wiki/email/spam.ltxt',
                                 {'spam_attempt': instance})
         send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,

--- a/kuma/wiki/content.py
+++ b/kuma/wiki/content.py
@@ -170,10 +170,10 @@ def extract_code_sample(id, src):
     if section:
         # HACK: Ensure the extracted section has a container, in case it
         # consists of a single element.
-        sample = pq('<section>%s</section>' % section)
+        sample = pq('<section>{0!s}</section>'.format(section))
     else:
         # If no section, fall back to plain old ID lookup
-        sample = pq(src).find('[id="%s"]' % id)
+        sample = pq(src).find('[id="{0!s}"]'.format(id))
 
     selector_templates = (
         '.%s',
@@ -219,7 +219,7 @@ def extract_html_attributes(content):
             if token['type'] == 'StartTag':
                 for (namespace, name), value in token['data'].items():
                     attribs.append((name, value))
-        return ['%s="%s"' % (k, v) for k, v in attribs]
+        return ['{0!s}="{1!s}"'.format(k, v) for k, v in attribs]
     except:
         return []
 
@@ -445,7 +445,7 @@ class LinkAnnotationFilter(html5lib_Filter):
                 # Check if this is a special docs path that's exempt from "new"
                 skip = False
                 for path in DOC_SPECIAL_PATHS:
-                    if '/docs/%s' % path in href:
+                    if '/docs/{0!s}'.format(path) in href:
                         skip = True
                 if skip:
                     continue
@@ -534,7 +534,7 @@ class SectionIDFilter(html5lib_Filter):
         """Generate a unique ID"""
         while True:
             self.id_cnt += 1
-            id = 'sect%s' % self.id_cnt
+            id = 'sect{0!s}'.format(self.id_cnt)
             if id not in self.known_ids:
                 self.known_ids.add(id)
                 return id
@@ -594,7 +594,7 @@ class SectionIDFilter(html5lib_Filter):
             start_inc = 2
             slug_base = slug
             while slug in self.known_ids:
-                slug = u'%s_%s' % (slug_base, start_inc)
+                slug = u'{0!s}_{1!s}'.format(slug_base, start_inc)
                 start_inc += 1
 
         attrs[(None, u'id')] = slug
@@ -699,14 +699,14 @@ class SectionEditLinkFilter(html5lib_Filter):
                                    (None, u'title'): ugettext('Edit section'),
                                    (None, u'class'): 'edit-section',
                                    (None, u'data-section-id'): value,
-                                   (None, u'data-section-src-url'): u'%s?%s' % (
+                                   (None, u'data-section-src-url'): u'{0!s}?{1!s}'.format(
                                        reverse('wiki.document',
                                                args=[self.slug],
                                                locale=self.locale),
                                        urlencode({'section': value.encode('utf-8'),
                                                   'raw': 'true'})
                                    ),
-                                   (None, u'href'): u'%s?%s' % (
+                                   (None, u'href'): u'{0!s}?{1!s}'.format(
                                        reverse('wiki.edit',
                                                args=[self.slug],
                                                locale=self.locale),
@@ -780,7 +780,7 @@ class SectionTOCFilter(html5lib_Filter):
                         {'type': 'StartTag', 'name': 'li', 'data': {}},
                         {'type': 'StartTag', 'name': 'a',
                          'data': {(None, u'rel'): 'internal',
-                                  (None, u'href'): '#%s' % id}},
+                                  (None, u'href'): '#{0!s}'.format(id)}},
                     ])
                     self.in_hierarchy = True
                     for t in out:
@@ -998,7 +998,7 @@ class CodeSyntaxFilter(html5lib_Filter):
                         if m:
                             lang = m.group(1).lower()
                             brush = MT_SYNTAX_BRUSH_MAP.get(lang, lang)
-                            attrs[(namespace, u'class')] = "brush: %s" % brush
+                            attrs[(namespace, u'class')] = "brush: {0!s}".format(brush)
                             del attrs[(None, 'function')]
                             token['data'] = attrs
             yield token

--- a/kuma/wiki/events.py
+++ b/kuma/wiki/events.py
@@ -66,8 +66,8 @@ class EditDocumentEvent(InstanceEvent):
     def _mails(self, users_and_watches):
         revision = self.revision
         document = revision.document
-        log.debug('Sending edited notification email for document (id=%s)' %
-                  document.id)
+        log.debug('Sending edited notification email for document (id={0!s})'.format(
+                  document.id))
         subject = ugettext(
             u'[MDN] Page "%(document_title)s" changed by %(creator)s')
         context = context_dict(revision)

--- a/kuma/wiki/feeds.py
+++ b/kuma/wiki/feeds.py
@@ -135,7 +135,7 @@ class DocumentJSONFeedGenerator(SyndicationFeed):
         data = items_out
 
         if callback:
-            outfile.write('%s(' % callback)
+            outfile.write('{0!s}('.format(callback))
         outfile.write(json.dumps(data, default=self._encode_complex))
         if callback:
             outfile.write(')')
@@ -152,7 +152,7 @@ class DocumentsRecentFeed(DocumentsFeed):
         super(DocumentsRecentFeed, self).get_object(request, format)
         self.tag = tag
         if tag:
-            self.title = _('MDN recent changes to documents tagged %s' % tag)
+            self.title = _('MDN recent changes to documents tagged {0!s}'.format(tag))
             self.link = self.request.build_absolute_uri(
                 reverse('wiki.tag', args=(tag,)))
         else:
@@ -186,7 +186,7 @@ class DocumentsReviewFeed(DocumentsRecentFeed):
         super(DocumentsReviewFeed, self).get_object(request, format)
         self.subtitle = None
         if tag:
-            self.title = _('MDN documents for %s review' % tag)
+            self.title = _('MDN documents for {0!s} review'.format(tag))
             self.link = self.request.build_absolute_uri(
                 reverse('wiki.list_review_tag', args=(tag,)))
         else:
@@ -220,8 +220,8 @@ class DocumentsUpdatedTranslationParentFeed(DocumentsFeed):
         super(DocumentsUpdatedTranslationParentFeed,
               self).get_object(request, format)
         self.subtitle = None
-        self.title = _("MDN '%s' translations in need of update" %
-                       self.locale)
+        self.title = _("MDN '{0!s}' translations in need of update".format(
+                       self.locale))
         # TODO: Need an HTML / dashboard version of this feed
         self.link = self.request.build_absolute_uri(
             reverse('wiki.all_documents'))
@@ -282,7 +282,7 @@ class RevisionsFeed(DocumentsFeed):
                                                   'document'))
 
     def item_title(self, item):
-        return '%s (%s)' % (item.document.slug, item.document.locale)
+        return '{0!s} ({1!s})'.format(item.document.slug, item.document.locale)
 
     def item_description(self, item):
         # TODO: put this in a jinja template if django syndication will let us
@@ -292,10 +292,10 @@ class RevisionsFeed(DocumentsFeed):
         else:
             action = u'Edited'
 
-        by = u'<h3>%s by:</h3><p>%s</p>' % (action, item.creator.username)
+        by = u'<h3>{0!s} by:</h3><p>{1!s}</p>'.format(action, item.creator.username)
 
         if item.comment:
-            comment = u'<h3>Comment:</h3><p>%s</p>' % item.comment
+            comment = u'<h3>Comment:</h3><p>{0!s}</p>'.format(item.comment)
         else:
             comment = u''
 
@@ -310,13 +310,13 @@ class RevisionsFeed(DocumentsFeed):
                 table = tag_diff_table(u','.join(prev_review_tags),
                                        u','.join(curr_review_tags),
                                        previous.id, item.id)
-                review_diff = u'<h3>Review changes:</h3>%s' % table
+                review_diff = u'<h3>Review changes:</h3>{0!s}'.format(table)
                 review_diff = colorize_diff(review_diff)
 
             if previous.tags != item.tags:
                 table = tag_diff_table(previous.tags, item.tags,
                                        previous.id, item.id)
-                tag_diff = u'<h3>Tag changes:</h3>%s' % table
+                tag_diff = u'<h3>Tag changes:</h3>{0!s}'.format(table)
                 tag_diff = colorize_diff(tag_diff)
 
         previous_content = ''
@@ -364,7 +364,7 @@ class RevisionsFeed(DocumentsFeed):
             _('History')
         )
         links_table = u'<table border="0" width="80%">'
-        links_table = links_table + u'<tr>%s%s%s%s</tr>' % (view_cell,
+        links_table = links_table + u'<tr>{0!s}{1!s}{2!s}{3!s}</tr>'.format(view_cell,
                                                             edit_cell,
                                                             compare_cell,
                                                             history_cell)

--- a/kuma/wiki/forms.py
+++ b/kuma/wiki/forms.py
@@ -344,7 +344,7 @@ class RevisionForm(AkismetCheckFormMixin, forms.ModelForm):
                 # Write a log we can grep to help find pre-existing duplicate
                 # document tags for cleanup.
                 if len(doc_tag) > 1:
-                    log.warn('Found duplicate document tags: %s' % doc_tag)
+                    log.warn('Found duplicate document tags: {0!s}'.format(doc_tag))
 
                 if doc_tag:
                     if doc_tag[0] != tag and doc_tag[0].lower() == tag.lower():
@@ -355,7 +355,7 @@ class RevisionForm(AkismetCheckFormMixin, forms.ModelForm):
 
                 cleaned_tags.append(tag)
 
-        return ' '.join([u'"%s"' % t for t in cleaned_tags])
+        return ' '.join([u'"{0!s}"'.format(t) for t in cleaned_tags])
 
     def clean_content(self):
         """

--- a/kuma/wiki/jobs.py
+++ b/kuma/wiki/jobs.py
@@ -42,7 +42,7 @@ class DocumentZoneURLRemapsJob(KumaJob):
         zones = (DocumentZone.objects.filter(document__locale=locale,
                                              url_root__isnull=False)
                                      .exclude(url_root=''))
-        remaps = [('/docs/%s' % zone.document.slug, '/%s' % zone.url_root)
+        remaps = [('/docs/{0!s}'.format(zone.document.slug), '/{0!s}'.format(zone.url_root))
                   for zone in zones]
         return remaps
 
@@ -83,7 +83,7 @@ class DocumentContributorsJob(KumaJob):
         # then return the ordered results given the ID list, MySQL only syntax
         select = collections.OrderedDict([
             ('ordered_ids',
-             'FIELD(id,%s)' % ','.join(map(str, recent_creator_ids))),
+             'FIELD(id,{0!s})'.format(','.join(map(str, recent_creator_ids)))),
         ])
         contributors = list(User.objects.filter(id__in=list(recent_creator_ids),
                                                 is_active=True)

--- a/kuma/wiki/kumascript.py
+++ b/kuma/wiki/kumascript.py
@@ -86,7 +86,7 @@ def _format_slug_for_request(slug):
     # http://bugzil.la/1063580
     index = slug.find(TEMPLATE_TITLE_PREFIX)
     if index != -1:
-        slug = '%s%s' % (TEMPLATE_TITLE_PREFIX, slug[(index + len(TEMPLATE_TITLE_PREFIX)):].lower())
+        slug = '{0!s}{1!s}'.format(TEMPLATE_TITLE_PREFIX, slug[(index + len(TEMPLATE_TITLE_PREFIX)):].lower())
     return slug
 
 
@@ -95,11 +95,11 @@ def get(document, cache_control, base_url, timeout=None):
     if not cache_control:
         # Default to the configured max-age for cache control.
         max_age = config.KUMASCRIPT_MAX_AGE
-        cache_control = 'max-age=%s' % max_age
+        cache_control = 'max-age={0!s}'.format(max_age)
 
     if not base_url:
         site = Site.objects.get_current()
-        base_url = 'http://%s' % site.domain
+        base_url = 'http://{0!s}'.format(site.domain)
 
     if not timeout:
         timeout = config.KUMASCRIPT_TIMEOUT
@@ -118,8 +118,7 @@ def get(document, cache_control, base_url, timeout=None):
 
     try:
         url_tmpl = settings.KUMASCRIPT_URL_TEMPLATE
-        url = unicode(url_tmpl).format(path=u'%s/%s' %
-                                       (document_locale,
+        url = unicode(url_tmpl).format(path=u'{0!s}/{1!s}'.format(document_locale,
                                         document_slug_for_kumascript))
 
         cache_keys = build_cache_keys(document_slug, document_locale)
@@ -195,8 +194,8 @@ def get(document, cache_control, base_url, timeout=None):
             errors = [
                 {
                     "level": "error",
-                    "message": "Unexpected response from Kumascript service: %s" %
-                               response.status_code,
+                    "message": "Unexpected response from Kumascript service: {0!s}".format(
+                               response.status_code),
                     "args": ["UnknownError"],
                 },
             ]
@@ -207,7 +206,7 @@ def get(document, cache_control, base_url, timeout=None):
         errors = [
             {
                 "level": "error",
-                "message": "Kumascript service failed unexpectedly: %s" % exc,
+                "message": "Kumascript service failed unexpectedly: {0!s}".format(exc),
                 "args": ["UnknownError"],
             },
         ]
@@ -217,7 +216,7 @@ def get(document, cache_control, base_url, timeout=None):
 def add_env_headers(headers, env_vars):
     """Encode env_vars as kumascript headers, as base64 JSON-encoded values."""
     headers.update(dict(
-        ('x-kumascript-env-%s' % k, base64.b64encode(json.dumps(v)))
+        ('x-kumascript-env-{0!s}'.format(k), base64.b64encode(json.dumps(v)))
         for k, v in env_vars.items()
     ))
     return headers
@@ -264,7 +263,7 @@ def process_errors(response):
         errors = [
             {
                 "level": "error",
-                "message": "Problem parsing errors: %s" % exc,
+                "message": "Problem parsing errors: {0!s}".format(exc),
                 "args": ["ParsingError"],
             },
         ]
@@ -273,9 +272,9 @@ def process_errors(response):
 
 def build_cache_keys(document_locale, document_slug):
     """Build the cache keys used for Kumascript"""
-    path_hash = hashlib.md5((u'%s/%s' % (document_locale, document_slug))
+    path_hash = hashlib.md5((u'{0!s}/{1!s}'.format(document_locale, document_slug))
                             .encode('utf8'))
-    base_key = 'kumascript:%s:%%s' % path_hash.hexdigest()
+    base_key = 'kumascript:{0!s}:%s'.format(path_hash.hexdigest())
     etag_key = base_key % 'etag'
     modified_key = base_key % 'modified'
     body_key = base_key % 'body'

--- a/kuma/wiki/management/commands/import_kumascript_modules.py
+++ b/kuma/wiki/management/commands/import_kumascript_modules.py
@@ -50,7 +50,7 @@ class Command(BaseCommand):
 
         print "Loaded docs:"
         for slug in loaded_docs:
-            print "%s" % slug
+            print "{0!s}".format(slug)
         print "\nSkipped docs that were already loaded:"
         for slug in skipped_docs:
-            print "%s" % slug
+            print "{0!s}".format(slug)

--- a/kuma/wiki/management/commands/refresh_wiki_caches.py
+++ b/kuma/wiki/management/commands/refresh_wiki_caches.py
@@ -43,8 +43,7 @@ class Command(BaseCommand):
             # Give some indication of progress, occasionally
             doc_cnt += 1
             if (doc_cnt % 5000) == 0:
-                logging.info("\t(%s / %s)" %
-                             (doc_cnt, doc_total))
+                logging.info("\t({0!s} / {1!s})".format(doc_cnt, doc_total))
 
             url = doc.get_absolute_url()
             if 'class="noinclude"' in doc.html and not doc.is_template:
@@ -64,12 +63,12 @@ class Command(BaseCommand):
 
         # Now, prefetch all the documents flagged in need in the previous loop.
         pre_total, pre_cnt = len(to_prefetch), 0
-        logging.info("Prefetching %s documents..." % (len(to_prefetch)))
+        logging.info("Prefetching {0!s} documents...".format((len(to_prefetch))))
         for url in to_prefetch:
             full_url = urlparse.urljoin(options['baseurl'], url)
             try:
                 pre_cnt += 1
-                logging.info("\t(%s/%s) %s" % (pre_cnt, pre_total, full_url))
+                logging.info("\t({0!s}/{1!s}) {2!s}".format(pre_cnt, pre_total, full_url))
                 requests.get(full_url)
             except Exception as e:
-                logging.error("\t\tFAILED: %s; %s" % (full_url, e))
+                logging.error("\t\tFAILED: {0!s}; {1!s}".format(full_url, e))

--- a/kuma/wiki/management/commands/render_document.py
+++ b/kuma/wiki/management/commands/render_document.py
@@ -83,7 +83,7 @@ class Command(BaseCommand):
                 if head == 'docs':
                     slug = tail
                 doc = Document.objects.get(locale=locale, slug=slug)
-                log.info(u'Rendering %s (%s)' % (doc, doc.get_absolute_url()))
+                log.info(u'Rendering {0!s} ({1!s})'.format(doc, doc.get_absolute_url()))
                 try:
                     render_document(doc.pk, self.cache_control, self.base_url,
                                     self.options['force'])

--- a/kuma/wiki/management/commands/repair_translation_breadcrumbs.py
+++ b/kuma/wiki/management/commands/repair_translation_breadcrumbs.py
@@ -21,8 +21,8 @@ class Command(BaseCommand):
                 .exclude(parent__exact=None)
                 .filter(parent_topic__exact=None))
 
-        logging.debug("Attempting breadcrumb repair for %s translations" %
-                      (docs.count()))
+        logging.debug("Attempting breadcrumb repair for {0!s} translations".format(
+                      (docs.count())))
 
         for doc in docs:
             doc.acquire_translated_topic_parent()
@@ -30,11 +30,11 @@ class Command(BaseCommand):
                 # Some translated pages really don't end up needing a
                 # breadcrumb repair, but we don't really know until we try and
                 # come up empty handed.
-                logging.debug(u'\t(root) -> /%s/docs/%s' % (
+                logging.debug(u'\t(root) -> /{0!s}/docs/{1!s}'.format(
                     doc.locale, doc.slug))
             else:
                 # We got a new parent topic, so save and report the result
                 doc.save()
-                logging.debug(u'\t/%s/docs/%s -> /%s/docs/%s' % (
+                logging.debug(u'\t/{0!s}/docs/{1!s} -> /{2!s}/docs/{3!s}'.format(
                     doc.parent_topic.locale, doc.parent_topic.slug,
                     doc.locale, doc.slug))

--- a/kuma/wiki/middleware.py
+++ b/kuma/wiki/middleware.py
@@ -41,7 +41,7 @@ class DocumentZoneMiddleware(object):
                 new_path = request.path_info.replace(original_path,
                                                      new_path,
                                                      1)
-                new_path = '/%s%s' % (request.LANGUAGE_CODE, new_path)
+                new_path = '/{0!s}{1!s}'.format(request.LANGUAGE_CODE, new_path)
 
                 query = request.GET.copy()
                 if 'lang' in query:

--- a/kuma/wiki/tasks.py
+++ b/kuma/wiki/tasks.py
@@ -45,7 +45,7 @@ def render_document(pk, cache_control, base_url, force=False):
     try:
         document.render(cache_control, base_url)
     except Exception as e:
-        subject = 'Exception while rendering document %s' % document.pk
+        subject = 'Exception while rendering document {0!s}'.format(document.pk)
         mail_admins(subject=subject, message=e)
     return document.rendered_errors
 
@@ -55,8 +55,8 @@ def email_render_document_progress(percent_complete, total):
     """
     Task to send email for render_document progress notification.
     """
-    subject = ('The command `render_document` is %s%% complete' %
-               percent_complete)
+    subject = ('The command `render_document` is {0!s}% complete'.format(
+               percent_complete))
     message = (
         'The command `render_document` is %s%% complete out of a total of '
         '%s documents to render.' % (percent_complete, total))
@@ -70,16 +70,15 @@ def render_document_chunk(pks, cache_control='no-cache', base_url=None,
     Simple task to render a chunk of documents instead of one per each
     """
     logger = render_document_chunk.get_logger()
-    logger.info(u'Starting to render document chunk: %s' %
-                ','.join([str(pk) for pk in pks]))
+    logger.info(u'Starting to render document chunk: {0!s}'.format(
+                ','.join([str(pk) for pk in pks])))
     base_url = base_url or settings.SITE_URL
     for pk in pks:
         # calling the task without delay here since we want to localize
         # the processing of the chunk in one process
         result = render_document(pk, cache_control, base_url, force=force)
         if result:
-            logger.error(u'Error while rendering document %s with error: %s' %
-                         (pk, result))
+            logger.error(u'Error while rendering document {0!s} with error: {1!s}'.format(pk, result))
     logger.info(u'Finished rendering of document chunk')
 
 
@@ -116,7 +115,7 @@ def render_stale_documents(log=None):
         # fetch a logger in case none is given
         log = render_stale_documents.get_logger()
 
-    log.info('Found %s stale documents' % stale_docs_count)
+    log.info('Found {0!s} stale documents'.format(stale_docs_count))
     stale_pks = stale_docs.values_list('pk', flat=True)
 
     pre_task = acquire_render_lock.si()
@@ -148,8 +147,8 @@ def move_page(locale, slug, new_slug, email):
         user = User.objects.get(email=email)
     except User.DoesNotExist:
         transaction.rollback()
-        logging.error('Page move failed: no user with email address %s' %
-                      email)
+        logging.error('Page move failed: no user with email address {0!s}'.format(
+                      email))
         return
 
     try:
@@ -159,9 +158,9 @@ def move_page(locale, slug, new_slug, email):
         message = """
             Page move failed.
 
-            Move was requested for document with slug %(slug)s in locale
-            %(locale)s, but no such document exists.
-        """ % {'slug': slug, 'locale': locale}
+            Move was requested for document with slug {slug!s} in locale
+            {locale!s}, but no such document exists.
+        """.format(**{'slug': slug, 'locale': locale})
         logging.error(message)
         send_mail('Page move failed',
                   textwrap.dedent(message),
@@ -177,13 +176,13 @@ def move_page(locale, slug, new_slug, email):
         message = """
             Page move failed.
 
-            Move was requested for document with slug %(slug)s in locale
-            %(locale)s, but could not be completed.
+            Move was requested for document with slug {slug!s} in locale
+            {locale!s}, but could not be completed.
 
             Diagnostic info:
 
-            %(message)s
-        """ % {'slug': slug, 'locale': locale, 'message': e.message}
+            {message!s}
+        """.format(**{'slug': slug, 'locale': locale, 'message': e.message})
         logging.error(message)
         send_mail('Page move failed',
                   textwrap.dedent(message),
@@ -196,11 +195,11 @@ def move_page(locale, slug, new_slug, email):
         message = """
             Page move failed.
 
-            Move was requested for document with slug %(slug)s in locale %(locale)s,
+            Move was requested for document with slug {slug!s} in locale {locale!s},
             but could not be completed.
 
-            %(info)s
-        """ % {'slug': slug, 'locale': locale, 'info': e}
+            {info!s}
+        """.format(**{'slug': slug, 'locale': locale, 'info': e})
         logging.error(message)
         send_mail('Page move failed',
                   textwrap.dedent(message),
@@ -223,11 +222,11 @@ def move_page(locale, slug, new_slug, email):
     message = """
         Page move completed.
 
-        The move requested for the document with slug %(slug)s in locale
-        %(locale)s, and all its children, has been completed.
+        The move requested for the document with slug {slug!s} in locale
+        {locale!s}, and all its children, has been completed.
 
-        You can now view this document at its new location: %(full_url)s.
-    """ % {'slug': slug, 'locale': locale, 'full_url': full_url}
+        You can now view this document at its new location: {full_url!s}.
+    """.format(**{'slug': slug, 'locale': locale, 'full_url': full_url})
 
     send_mail(subject,
               textwrap.dedent(message),
@@ -287,8 +286,8 @@ def send_first_edit_email(revision_pk):
     """ Make an 'edited' notification email for first-time editors """
     revision = Revision.objects.get(pk=revision_pk)
     user, doc = revision.creator, revision.document
-    subject = (u"[MDN] %(user)s made their first edit, to: %(doc)s" %
-               {'user': user.username, 'doc': doc.title})
+    subject = (u"[MDN] {user!s} made their first edit, to: {doc!s}".format(**
+               {'user': user.username, 'doc': doc.title}))
     message = render_to_string('wiki/email/edited.ltxt',
                                context_dict(revision))
     doc_url = absolutify(doc.get_absolute_url())
@@ -317,7 +316,7 @@ def build_locale_sitemap(locale):
     build.
     """
     now = datetime.utcnow()
-    timestamp = '%s+00:00' % now.replace(microsecond=0).isoformat()
+    timestamp = '{0!s}+00:00'.format(now.replace(microsecond=0).isoformat())
 
     directory = os.path.join(settings.MEDIA_ROOT, 'sitemaps', locale)
     if not os.path.isdir(directory):
@@ -336,7 +335,7 @@ def build_locale_sitemap(locale):
             if page == 1:
                 name = 'sitemap.xml'
             else:
-                name = 'sitemap_%s.xml' % page
+                name = 'sitemap_{0!s}.xml'.format(page)
             names.append(name)
 
             rendered = smart_str(render_to_string('wiki/sitemap.xml',
@@ -361,7 +360,7 @@ def build_index_sitemap(results):
         if result is not None:
             locale, names, timestamp = result
             for name in names:
-                sitemap_url = absolutify('/sitemaps/%s/%s' % (locale, name))
+                sitemap_url = absolutify('/sitemaps/{0!s}/{1!s}'.format(locale, name))
                 sitemap_parts.append(SITEMAP_ELEMENT % (sitemap_url, timestamp))
 
     sitemap_parts.append(SITEMAP_END)

--- a/kuma/wiki/templatetags/jinja_helpers.py
+++ b/kuma/wiki/templatetags/jinja_helpers.py
@@ -70,8 +70,8 @@ def revisions_unified_diff(from_revision, to_revision):
     if from_revision is None or to_revision is None:
         return "Diff is unavailable."
 
-    fromfile = '[%s] #%s' % (from_revision.document.locale, from_revision.id)
-    tofile = '[%s] #%s' % (to_revision.document.locale, to_revision.id)
+    fromfile = '[{0!s}] #{1!s}'.format(from_revision.document.locale, from_revision.id)
+    tofile = '[{0!s}] #{1!s}'.format(to_revision.document.locale, to_revision.id)
 
     tidy_from = from_revision.get_tidied_content()
     tidy_to = to_revision.get_tidied_content()
@@ -104,7 +104,7 @@ def diff_table(content_from, content_to, prev_id, curr_id, tidy=False):
     except RuntimeError:
         # some diffs hit a max recursion error
         message = ugettext(u'There was an error generating the content.')
-        diff = '<div class="warning"><p>%s</p></div>' % message
+        diff = '<div class="warning"><p>{0!s}</p></div>'.format(message)
     return jinja2.Markup(diff)
 
 
@@ -206,7 +206,7 @@ def document_zone_management_links(user, document):
     # zone but the document is not itself the root (ie. to add sub-zones).
     if ((not zone or zone.document != document) and
             user.has_perm('wiki.add_documentzone')):
-        links['add'] = '%s?document=%s' % (
+        links['add'] = '{0!s}?document={1!s}'.format(
             reverse('admin:wiki_documentzone_add'), document.id)
 
     # Enable "change" link if there's a zone, and the user has permission.

--- a/kuma/wiki/tests/__init__.py
+++ b/kuma/wiki/tests/__init__.py
@@ -153,7 +153,7 @@ def create_document_editor_user():
     """Creates a user empowered with document editing"""
     perms = []
     for action in ('add', 'change', 'delete', 'view', 'restore'):
-        perms.append(Permission.objects.get(codename='%s_document' % action))
+        perms.append(Permission.objects.get(codename='{0!s}_document'.format(action)))
 
     group, group_created = Group.objects.get_or_create(name='editor')
     if group_created:
@@ -175,7 +175,7 @@ def create_document_editor_user():
 
 def create_template_test_users():
     perms = dict(
-        (x, [Permission.objects.get(codename='%s_template_document' % x)])
+        (x, [Permission.objects.get(codename='{0!s}_template_document'.format(x))])
         for x in ('add', 'change',)
     )
     perms['all'] = perms['add'] + perms['change']
@@ -183,7 +183,7 @@ def create_template_test_users():
     groups = {}
     for x in ('add', 'change', 'all'):
         group, created = Group.objects.get_or_create(
-            name='templaters_%s' % x)
+            name='templaters_{0!s}'.format(x))
         if created:
             group.permissions = perms[x]
             group.save()
@@ -193,7 +193,7 @@ def create_template_test_users():
     User = get_user_model()
     for x in ('none', 'add', 'change', 'all'):
         user, created = User.objects.get_or_create(
-            username='user_%s' % x,
+            username='user_{0!s}'.format(x),
             defaults=dict(email='user_%s@example.com',
                           is_active=True, is_staff=False, is_superuser=False))
         if created:

--- a/kuma/wiki/tests/test_content.py
+++ b/kuma/wiki/tests/test_content.py
@@ -68,7 +68,7 @@ class ContentSectionToolTests(UserTestCase):
             ('Quick_Links', 'Quick_Links'),
         )
         for cls, id in expected:
-            eq_(id, result_doc.find('.%s' % cls).attr('id'))
+            eq_(id, result_doc.find('.{0!s}'.format(cls)).attr('id'))
 
         # Then, ensure all elements in need of an ID now all have unique IDs.
         ok_(len(SECTION_TAGS) > 0)
@@ -606,13 +606,13 @@ class ContentSectionToolTests(UserTestCase):
 
             <ul id="sample2" class="code-sample">
                 <li><span>HTML</span>
-                    <pre class="brush: html">%s</pre>
+                    <pre class="brush: html">{0!s}</pre>
                 </li>
                 <li><span>CSS</span>
-                    <pre class="brush:css;random:crap;in:the;classname">%s</pre>
+                    <pre class="brush:css;random:crap;in:the;classname">{1!s}</pre>
                 </li>
                 <li><span>JS</span>
-                    <pre class="brush: js">%s</pre>
+                    <pre class="brush: js">{2!s}</pre>
                 </li>
             </ul>
 
@@ -632,7 +632,7 @@ class ContentSectionToolTests(UserTestCase):
             </div>
 
             <p>Yadda yadda</p>
-        """ % (escape(sample_html), escape(sample_css), escape(sample_js))
+        """.format(escape(sample_html), escape(sample_css), escape(sample_js))
 
         # live sample using the section logic
         result = kuma.wiki.content.extract_code_sample('sample0', doc_src)
@@ -706,20 +706,20 @@ class ContentSectionToolTests(UserTestCase):
 
     def test_iframe_host_filter(self):
         slug = 'test-code-embed'
-        embed_url = 'https://sampleserver/en-US/docs/%s$samples/sample1' % slug
+        embed_url = 'https://sampleserver/en-US/docs/{0!s}$samples/sample1'.format(slug)
 
         doc_src = """
             <p>This is a page. Deal with it.</p>
             <div id="sample1" class="code-sample">
                 <pre class="brush: html">Some HTML</pre>
-                <pre class="brush: css">.some-css { color: red; }</pre>
+                <pre class="brush: css">.some-css {{ color: red; }}</pre>
                 <pre class="brush: js">window.alert("HI THERE")</pre>
             </div>
-            <iframe id="if1" src="%(embed_url)s"></iframe>
+            <iframe id="if1" src="{embed_url!s}"></iframe>
             <iframe id="if2" src="http://testserver"></iframe>
             <iframe id="if3" src="https://some.alien.site.com"></iframe>
             <p>test</p>
-        """ % dict(embed_url=embed_url)
+        """.format(**dict(embed_url=embed_url))
 
         result_src = (kuma.wiki.content.parse(doc_src)
                       .filterIframeHosts('^https?\:\/\/sampleserver')
@@ -763,11 +763,11 @@ class ContentSectionToolTests(UserTestCase):
             'https://youtube.com/sembed/'
         )
         doc_src = """
-            <iframe id="if1" src="%s"></iframe>
-            <iframe id="if2" src="%s"></iframe>
-            <iframe id="if3" src="%s"></iframe>
+            <iframe id="if1" src="{0!s}"></iframe>
+            <iframe id="if2" src="{1!s}"></iframe>
+            <iframe id="if3" src="{2!s}"></iframe>
             <p>test</p>
-        """ % tubes
+        """.format(*tubes)
         result_src = (kuma.wiki.content.parse(doc_src)
                       .filterIframeHosts('^https?\:\/\/(www.)?youtube.com\/embed\/(\.*)')
                       .serialize())
@@ -821,7 +821,7 @@ class ContentSectionToolTests(UserTestCase):
             base_url=base_url,
             exist_url=d.get_absolute_url(),
             exist_url_with_base=urljoin(base_url, d.get_absolute_url()),
-            uilocale_url=u'/en-US/docs/%s/%s' % (d.locale, d.slug),
+            uilocale_url=u'/en-US/docs/{0!s}/{1!s}'.format(d.locale, d.slug),
             noexist_url=u'/en-US/docs/no-such-doc',
             noexist_url_with_base=urljoin(base_url,
                                           u'/en-US/docs/no-such-doc'),
@@ -832,57 +832,57 @@ class ContentSectionToolTests(UserTestCase):
             templates_url='/en-US/docs/templates',
         )
         doc_src = u"""
-                <li><a href="%(nonen_slug)s">Héritée</a></li>
-                <li><a href="%(exist_url)s">This doc should exist</a></li>
-                <li><a href="%(exist_url)s#withanchor">This doc should exist</a></li>
-                <li><a href="%(exist_url_with_base)s">This doc should exist</a></li>
-                <li><a href="%(exist_url_with_base)s#withanchor">This doc should exist</a></li>
-                <li><a href="%(uilocale_url)s">This doc should exist</a></li>
-                <li><a class="foobar" href="%(exist_url)s">This doc should exist, and its class should be left alone.</a></li>
-                <li><a href="%(noexist_url)s#withanchor">This doc should NOT exist</a></li>
-                <li><a href="%(noexist_url)s">This doc should NOT exist</a></li>
-                <li><a href="%(noexist_url_with_base)s">This doc should NOT exist</a></li>
-                <li><a href="%(noexist_url_with_base)s#withanchor">This doc should NOT exist</a></li>
-                <li><a href="%(noexist_uilocale_url)s">This doc should NOT exist</a></li>
-                <li><a class="foobar" href="%(noexist_url)s">This doc should NOT exist, and its class should be altered</a></li>
+                <li><a href="{nonen_slug!s}">Héritée</a></li>
+                <li><a href="{exist_url!s}">This doc should exist</a></li>
+                <li><a href="{exist_url!s}#withanchor">This doc should exist</a></li>
+                <li><a href="{exist_url_with_base!s}">This doc should exist</a></li>
+                <li><a href="{exist_url_with_base!s}#withanchor">This doc should exist</a></li>
+                <li><a href="{uilocale_url!s}">This doc should exist</a></li>
+                <li><a class="foobar" href="{exist_url!s}">This doc should exist, and its class should be left alone.</a></li>
+                <li><a href="{noexist_url!s}#withanchor">This doc should NOT exist</a></li>
+                <li><a href="{noexist_url!s}">This doc should NOT exist</a></li>
+                <li><a href="{noexist_url_with_base!s}">This doc should NOT exist</a></li>
+                <li><a href="{noexist_url_with_base!s}#withanchor">This doc should NOT exist</a></li>
+                <li><a href="{noexist_uilocale_url!s}">This doc should NOT exist</a></li>
+                <li><a class="foobar" href="{noexist_url!s}">This doc should NOT exist, and its class should be altered</a></li>
                 <li><a href="http://mozilla.org/">This is an external link</a></li>
                 <li><a class="foobar" name="quux">A lack of href should not cause a problem.</a></li>
                 <li><a>In fact, a "link" with no attributes should be no problem as well.</a></li>
-                <a href="%(tag_url)s">Tag link</a>
-                <a href="%(feed_url)s">Feed link</a>
-                <a href="%(templates_url)s">Templates link</a>
+                <a href="{tag_url!s}">Tag link</a>
+                <a href="{feed_url!s}">Feed link</a>
+                <a href="{templates_url!s}">Templates link</a>
                 <a href="/en-US/docs/DOM/stylesheet">Case sensitive 1</a>
                 <a href="/en-US/docs/DOM/Stylesheet">Case sensitive 1</a>
                 <a href="/en-US/docs/DOM/StyleSheet">Case sensitive 1</a>
                 <a href="/en-us/docs/dom/StyleSheet">Case sensitive 1</a>
                 <a href="/en-US/docs/dom/Styles">For good measure</a>
-        """ % vars
+        """.format(**vars)
         expected = u"""
-                <li><a href="%(nonen_slug)s">Héritée</a></li>
-                <li><a href="%(exist_url)s">This doc should exist</a></li>
-                <li><a href="%(exist_url)s#withanchor">This doc should exist</a></li>
-                <li><a href="%(exist_url_with_base)s">This doc should exist</a></li>
-                <li><a href="%(exist_url_with_base)s#withanchor">This doc should exist</a></li>
-                <li><a href="%(uilocale_url)s">This doc should exist</a></li>
-                <li><a class="foobar" href="%(exist_url)s">This doc should exist, and its class should be left alone.</a></li>
-                <li><a class="new" href="%(noexist_url)s#withanchor">This doc should NOT exist</a></li>
-                <li><a class="new" href="%(noexist_url)s">This doc should NOT exist</a></li>
-                <li><a class="new" href="%(noexist_url_with_base)s">This doc should NOT exist</a></li>
-                <li><a class="new" href="%(noexist_url_with_base)s#withanchor">This doc should NOT exist</a></li>
-                <li><a class="new" href="%(noexist_uilocale_url)s">This doc should NOT exist</a></li>
-                <li><a class="foobar new" href="%(noexist_url)s">This doc should NOT exist, and its class should be altered</a></li>
+                <li><a href="{nonen_slug!s}">Héritée</a></li>
+                <li><a href="{exist_url!s}">This doc should exist</a></li>
+                <li><a href="{exist_url!s}#withanchor">This doc should exist</a></li>
+                <li><a href="{exist_url_with_base!s}">This doc should exist</a></li>
+                <li><a href="{exist_url_with_base!s}#withanchor">This doc should exist</a></li>
+                <li><a href="{uilocale_url!s}">This doc should exist</a></li>
+                <li><a class="foobar" href="{exist_url!s}">This doc should exist, and its class should be left alone.</a></li>
+                <li><a class="new" href="{noexist_url!s}#withanchor">This doc should NOT exist</a></li>
+                <li><a class="new" href="{noexist_url!s}">This doc should NOT exist</a></li>
+                <li><a class="new" href="{noexist_url_with_base!s}">This doc should NOT exist</a></li>
+                <li><a class="new" href="{noexist_url_with_base!s}#withanchor">This doc should NOT exist</a></li>
+                <li><a class="new" href="{noexist_uilocale_url!s}">This doc should NOT exist</a></li>
+                <li><a class="foobar new" href="{noexist_url!s}">This doc should NOT exist, and its class should be altered</a></li>
                 <li><a class="external" href="http://mozilla.org/">This is an external link</a></li>
                 <li><a class="foobar" name="quux">A lack of href should not cause a problem.</a></li>
                 <li><a>In fact, a "link" with no attributes should be no problem as well.</a></li>
-                <a href="%(tag_url)s">Tag link</a>
-                <a href="%(feed_url)s">Feed link</a>
-                <a href="%(templates_url)s">Templates link</a>
+                <a href="{tag_url!s}">Tag link</a>
+                <a href="{feed_url!s}">Feed link</a>
+                <a href="{templates_url!s}">Templates link</a>
                 <a href="/en-US/docs/DOM/stylesheet">Case sensitive 1</a>
                 <a href="/en-US/docs/DOM/Stylesheet">Case sensitive 1</a>
                 <a href="/en-US/docs/DOM/StyleSheet">Case sensitive 1</a>
                 <a href="/en-us/docs/dom/StyleSheet">Case sensitive 1</a>
                 <a class="new" href="/en-US/docs/dom/Styles">For good measure</a>
-        """ % vars
+        """.format(**vars)
 
         # Split the markup into lines, to better see failures
         doc_lines = doc_src.strip().split("\n")
@@ -1013,12 +1013,12 @@ class AllowedHTMLTests(KumaTestCase):
 
     def test_allowed_tags(self):
         for tag in self.simple_tags:
-            html_str = '<%(tag)s></%(tag)s>' % {'tag': tag}
+            html_str = '<{tag!s}></{tag!s}>'.format(**{'tag': tag})
             eq_(html_str, bleach.clean(html_str, attributes=ALLOWED_ATTRIBUTES,
                                        tags=ALLOWED_TAGS))
 
         for tag in self.unclose_tags:
-            html_str = '<%s>' % tag
+            html_str = '<{0!s}>'.format(tag)
             eq_(html_str, bleach.clean(html_str, attributes=ALLOWED_ATTRIBUTES,
                                        tags=ALLOWED_TAGS))
 
@@ -1032,7 +1032,7 @@ class AllowedHTMLTests(KumaTestCase):
                     'article', 'aside', 'figure', 'dialog', 'hgroup', 'mark',
                     'time', 'meter', 'output', 'progress', 'audio', 'details',
                     'datagrid', 'datalist', 'address'):
-            html_str = '<%(tag)s id="foo"></%(tag)s>' % {'tag': tag}
+            html_str = '<{tag!s} id="foo"></{tag!s}>'.format(**{'tag': tag})
             eq_(html_str, bleach.clean(html_str, attributes=ALLOWED_ATTRIBUTES,
                                        tags=ALLOWED_TAGS))
 
@@ -1062,10 +1062,10 @@ class SearchParserTests(KumaTestCase):
     def test_css_classname_extraction(self):
         expected = ('foobar', 'barfoo', 'bazquux')
         content = """
-            <p class="%s">Test</p>
-            <p class="%s">Test</p>
-            <div class="%s">Test</div>
-        """ % expected
+            <p class="{0!s}">Test</p>
+            <p class="{1!s}">Test</p>
+            <div class="{2!s}">Test</div>
+        """.format(*expected)
         result = extract_css_classnames(content)
         eq_(sorted(expected), sorted(result))
 
@@ -1076,21 +1076,21 @@ class SearchParserTests(KumaTestCase):
             'data-boof="farb"'
         )
         content = """
-            <p %s>Test</p>
-            <p %s>Test</p>
-            <div %s>Test</div>
-        """ % expected
+            <p {0!s}>Test</p>
+            <p {1!s}>Test</p>
+            <div {2!s}>Test</div>
+        """.format(*expected)
         result = extract_html_attributes(content)
         eq_(sorted(expected), sorted(result))
 
     def test_kumascript_macro_extraction(self):
         expected = ('foobar', 'barfoo', 'bazquux', 'banana')
         content = """
-            <p>{{ %s }}</p>
-            <p>{{ %s("foo", "bar", "baz") }}</p>
-            <p>{{ %s    ("quux") }}</p>
-            <p>{{%s}}</p>
-        """ % expected
+            <p>{{{{ {0!s} }}}}</p>
+            <p>{{{{ {1!s}("foo", "bar", "baz") }}}}</p>
+            <p>{{{{ {2!s}    ("quux") }}}}</p>
+            <p>{{{{{3!s}}}}}</p>
+        """.format(*expected)
         result = extract_kumascript_macro_names(content)
         eq_(sorted(expected), sorted(result))
 

--- a/kuma/wiki/tests/test_feeds.py
+++ b/kuma/wiki/tests/test_feeds.py
@@ -50,9 +50,9 @@ class FeedTests(UserTestCase, WikiTestCase):
         self.assertEqual(1, len(feed.find('item')))
         for i, item in enumerate(feed.find('item')):
             desc_text = pq(item).find('description').text()
-            compare_url = '%s$compare?to=%s&from=%s&utm_campaign=feed' % (
+            compare_url = '{0!s}$compare?to={1!s}&from={2!s}&utm_campaign=feed'.format(
                 d1.slug, d1.current_revision.id, first_rev_id)
-            edit_url = '%s$edit?utm_campaign=feed&utm_medium=rss' % d2.slug
+            edit_url = '{0!s}$edit?utm_campaign=feed&utm_medium=rss'.format(d2.slug)
             self.assertTrue(escape(compare_url) in desc_text)
             self.assertTrue(escape(edit_url) in desc_text)
 
@@ -65,8 +65,8 @@ class FeedTests(UserTestCase, WikiTestCase):
             revision(save=True,
                      document=d,
                      title='HTML9',
-                     comment='Revision %s' % i,
-                     content="Some Content %s" % i,
+                     comment='Revision {0!s}'.format(i),
+                     content="Some Content {0!s}".format(i),
                      is_approved=True,
                      created=created)
 
@@ -114,16 +114,16 @@ class FeedTests(UserTestCase, WikiTestCase):
             revision(save=True,
                      document=d,
                      title='HTML9',
-                     comment='Revision %s' % i,
-                     content="Some Content %s" % i,
+                     comment='Revision {0!s}'.format(i),
+                     content="Some Content {0!s}".format(i),
                      is_approved=True,
                      created=created)
 
-        resp = self.client.get('%s?all_locales' %
+        resp = self.client.get('{0!s}?all_locales'.format(
                                reverse('wiki.feeds.recent_revisions',
                                        args=(),
                                        kwargs={'format': 'rss'},
-                                       locale='en-US'))
+                                       locale='en-US')))
         self.assertEqual(200, resp.status_code)
         feed = pq(resp.content)
         self.assertEqual(5, len(feed.find('item')))
@@ -253,7 +253,7 @@ class FeedTests(UserTestCase, WikiTestCase):
                 )
                 for feed_url in feed_urls:
                     if show_all:
-                        feed_url = '%s?all_locales' % feed_url
+                        feed_url = '{0!s}?all_locales'.format(feed_url)
                     resp = self.client.get(feed_url)
                     data = json.loads(resp.content)
                     if show_all:

--- a/kuma/wiki/tests/test_helpers.py
+++ b/kuma/wiki/tests/test_helpers.py
@@ -71,8 +71,8 @@ class DocumentZoneTests(UserTestCase, WikiTestCase):
         """
         self.root_content = """
             <h4 id="links">Links</h4>
-            %s
-        """ % (self.root_links_content)
+            {0!s}
+        """.format((self.root_links_content))
 
         root_rev = revision(title='ZoneRoot',
                             slug='ZoneRoot',
@@ -101,8 +101,8 @@ class DocumentZoneTests(UserTestCase, WikiTestCase):
         """
         self.sub_sub_content = """
             <h4 id="links">Links</h4>
-            %s
-        """ % (self.sub_sub_links_content)
+            {0!s}
+        """.format((self.sub_sub_links_content))
 
         sub_sub_rev = revision(title='SubSubPage',
                                slug='SubSubPage',

--- a/kuma/wiki/tests/test_middleware.py
+++ b/kuma/wiki/tests/test_middleware.py
@@ -69,12 +69,12 @@ class DocumentZoneMiddlewareTestCase(UserTestCase, WikiTestCase):
     def test_url_root_internal_redirect(self):
         """Ensure document zone with URL root results in internal redirect"""
 
-        url = '/en-US/%s?raw' % self.zone_root
+        url = '/en-US/{0!s}?raw'.format(self.zone_root)
         response = self.client.get(url, follow=False)
         eq_(200, response.status_code)
         eq_(self.zone_root_content, response.content)
 
-        url = '/en-US/%s/Middle/SubPage?raw' % self.zone_root
+        url = '/en-US/{0!s}/Middle/SubPage?raw'.format(self.zone_root)
         response = self.client.get(url, follow=False)
         eq_(200, response.status_code)
         eq_(self.sub_doc.html, response.content)
@@ -82,7 +82,7 @@ class DocumentZoneMiddlewareTestCase(UserTestCase, WikiTestCase):
         self.root_zone.url_root = 'NewRoot'
         self.root_zone.save()
 
-        url = '/en-US/%s/Middle/SubPage?raw' % 'NewRoot'
+        url = '/en-US/{0!s}/Middle/SubPage?raw'.format('NewRoot')
         response = self.client.get(url, follow=False)
         eq_(200, response.status_code)
         eq_(self.sub_doc.html, response.content)
@@ -92,7 +92,7 @@ class DocumentZoneMiddlewareTestCase(UserTestCase, WikiTestCase):
         Ensure a request for the 'real' path to a document results in a
         redirect to the internal redirect path
         """
-        url = '/en-US/docs/%s?raw=1' % self.middle_doc.slug
+        url = '/en-US/docs/{0!s}?raw=1'.format(self.middle_doc.slug)
         response = self.client.get(url, follow=False)
         eq_(302, response.status_code)
         eq_('http://testserver/en-US/ExtraWiki/Middle?raw=1',
@@ -101,7 +101,7 @@ class DocumentZoneMiddlewareTestCase(UserTestCase, WikiTestCase):
         self.root_zone.url_root = 'NewRoot'
         self.root_zone.save()
 
-        url = '/en-US/docs/%s?raw=1' % self.middle_doc.slug
+        url = '/en-US/docs/{0!s}?raw=1'.format(self.middle_doc.slug)
         response = self.client.get(url, follow=False)
         eq_(302, response.status_code)
         eq_('http://testserver/en-US/NewRoot/Middle?raw=1',
@@ -109,7 +109,7 @@ class DocumentZoneMiddlewareTestCase(UserTestCase, WikiTestCase):
 
     def test_blank_url_root(self):
         """Ensure a blank url_root does not trigger URL remap"""
-        url = '/en-US/docs/%s?raw=1' % self.other_doc.slug
+        url = '/en-US/docs/{0!s}?raw=1'.format(self.other_doc.slug)
         response = self.client.get(url, follow=False)
         eq_(200, response.status_code)
 
@@ -137,6 +137,6 @@ class DocumentZoneMiddlewareTestCase(UserTestCase, WikiTestCase):
         non_zone_doc = none_zone_rev.document
         non_zone_doc.save()
 
-        url = '/en-US/docs/%s' % non_zone_doc.slug
+        url = '/en-US/docs/{0!s}'.format(non_zone_doc.slug)
         response = self.client.get(url, follow=False)
         eq_(200, response.status_code)

--- a/kuma/wiki/tests/test_models.py
+++ b/kuma/wiki/tests/test_models.py
@@ -39,7 +39,7 @@ def _objects_eq(manager, list_):
 def redirect_rev(title, redirect_to):
     return revision(
         document=document(title=title, save=True),
-        content='REDIRECT [[%s]]' % redirect_to,
+        content='REDIRECT [[{0!s}]]'.format(redirect_to),
         is_approved=True,
         save=True)
 
@@ -114,7 +114,7 @@ class DocumentTests(UserTestCase):
 
         assert not d.is_template
 
-        d.slug = '%stest' % TEMPLATE_TITLE_PREFIX
+        d.slug = '{0!s}test'.format(TEMPLATE_TITLE_PREFIX)
         d.save()
 
         assert d.is_template
@@ -252,7 +252,7 @@ class DocumentTests(UserTestCase):
 
     @pytest.mark.redirect
     def test_redirect_url_allows_site_url(self):
-        href = "%s/en-US/Mozilla" % settings.SITE_URL
+        href = "{0!s}/en-US/Mozilla".format(settings.SITE_URL)
         title = "Mozilla"
         html = REDIRECT_CONTENT % {'href': href, 'title': title}
         d = document(is_redirect=True, html=html)
@@ -324,17 +324,17 @@ class PermissionTests(KumaTestCase):
                     if is_add:
                         eq_(expected,
                             Document.objects.allows_add_by(trial_user, slug),
-                            'User %s %s able to create %s' % (
+                            'User {0!s} {1!s} able to create {2!s}'.format(
                                 trial_user, msg[expected], slug))
                     else:
                         doc = document(slug=slug, title=slug)
                         eq_(expected,
                             doc.allows_revision_by(trial_user),
-                            'User %s %s able to revise %s' % (
+                            'User {0!s} {1!s} able to revise {2!s}'.format(
                                 trial_user, msg[expected], slug))
                         eq_(expected,
                             doc.allows_editing_by(trial_user),
-                            'User %s %s able to edit %s' % (
+                            'User {0!s} {1!s} able to edit {2!s}'.format(
                                 trial_user, msg[expected], slug))
 
 
@@ -469,12 +469,12 @@ class DocumentTestsWithFixture(UserTestCase):
         doc_src = u"""
             <p>This is a page. Deal with it.</p>
             <ul id="s2" class="code-sample">
-                <li><pre class="brush: html">%s</pre></li>
-                <li><pre class="brush: css">%s</pre></li>
-                <li><pre class="brush: js">%s</pre></li>
+                <li><pre class="brush: html">{0!s}</pre></li>
+                <li><pre class="brush: css">{1!s}</pre></li>
+                <li><pre class="brush: js">{2!s}</pre></li>
             </ul>
             <p>More content shows up here.</p>
-        """ % (escape(sample_html), escape(sample_css), escape(sample_js))
+        """.format(escape(sample_html), escape(sample_css), escape(sample_js))
 
         d1, r1 = doc_rev(doc_src)
         result = d1.extract_code_sample('s2')
@@ -533,7 +533,7 @@ class RevisionTests(UserTestCase):
         d, _ = doc_rev('Replace document html')
 
         assert 'Replace document html' in d.html, \
-               '"Replace document html" not in %s' % d.html
+               '"Replace document html" not in {0!s}'.format(d.html)
 
         # Creating another approved revision replaces it again
         r = revision(document=d, content='Replace html again',
@@ -541,20 +541,20 @@ class RevisionTests(UserTestCase):
         r.save()
 
         assert 'Replace html again' in d.html, \
-               '"Replace html again" not in %s' % d.html
+               '"Replace html again" not in {0!s}'.format(d.html)
 
     def test_unapproved_revision_not_updates_html(self):
         """Creating an unapproved revision does not update document.html"""
         d, _ = doc_rev('Here to stay')
 
-        assert 'Here to stay' in d.html, '"Here to stay" not in %s' % d.html
+        assert 'Here to stay' in d.html, '"Here to stay" not in {0!s}'.format(d.html)
 
         # Creating another approved revision keeps initial content
         r = revision(document=d, content='Fail to replace html',
                      is_approved=False)
         r.save()
 
-        assert 'Here to stay' in d.html, '"Here to stay" not in %s' % d.html
+        assert 'Here to stay' in d.html, '"Here to stay" not in {0!s}'.format(d.html)
 
     def test_revision_unicode(self):
         """Revision containing unicode characters is saved successfully."""
@@ -1565,7 +1565,7 @@ class PageMoveTests(UserTestCase):
     @pytest.mark.move
     def test_move_special(self):
         root_slug = 'User:foo'
-        child_slug = '%s/child' % root_slug
+        child_slug = '{0!s}/child'.format(root_slug)
 
         new_root_slug = 'User:foobar'
 
@@ -1609,7 +1609,7 @@ class PageMoveTests(UserTestCase):
                                           slug=new_root_slug)
         eq_(original_root_id, moved_root.id)
         moved_child = Document.objects.get(locale=special_child.locale,
-                                           slug='%s/child' % new_root_slug)
+                                           slug='{0!s}/child'.format(new_root_slug))
         eq_(original_child_id, moved_child.id)
 
         # Second move, back to original slug.
@@ -1620,7 +1620,7 @@ class PageMoveTests(UserTestCase):
                                                     slug=new_root_slug)
         ok_(root_second_redirect.is_redirect)
         child_second_redirect = Document.objects.get(locale=special_child.locale,
-                                                     slug='%s/child' % new_root_slug)
+                                                     slug='{0!s}/child'.format(new_root_slug))
         ok_(child_second_redirect.is_redirect)
 
         # The documents at the original URLs aren't redirects anymore.
@@ -1679,8 +1679,8 @@ class PageMoveTests(UserTestCase):
             child_doc._move_tree('test-move-error-messaging/moved')
         except PageMoveError as e:
             err_strings = [
-                'with id %s' % grandchild_doc.id,
-                'https://developer.mozilla.org/%s/docs/%s' % (grandchild_doc.locale,
+                'with id {0!s}'.format(grandchild_doc.id),
+                'https://developer.mozilla.org/{0!s}/docs/{1!s}'.format(grandchild_doc.locale,
                                                               grandchild_doc.slug),
                 "Exception type: <type 'exceptions.Exception'>",
                 'Exception message: Requested move would overwrite a non-redirect page.',

--- a/kuma/wiki/tests/test_tasks.py
+++ b/kuma/wiki/tests/test_tasks.py
@@ -57,8 +57,8 @@ class SitemapsTestCase(UserTestCase):
         for locale in set(locales):
             # we'll expect to see this locale in the sitemap index file
             expected_sitemap_locs.append(
-                "<loc>https://example.com/sitemaps/%s/sitemap.xml</loc>" %
-                locale
+                "<loc>https://example.com/sitemaps/{0!s}/sitemap.xml</loc>".format(
+                locale)
             )
             sitemap_path = os.path.join(settings.MEDIA_ROOT, 'sitemaps',
                                         locale, 'sitemap.xml')

--- a/kuma/wiki/tests/test_templates.py
+++ b/kuma/wiki/tests/test_templates.py
@@ -80,7 +80,7 @@ class DocumentTests(UserTestCase, WikiTestCase):
         eq_(200, response.status_code)
         doc = pq(response.content)
         eq_(d2.title, doc('main#content div.document-head h1').text())
-        crumbs = "MDN %s %s" % (d1.title, d2.title)
+        crumbs = "MDN {0!s} {1!s}".format(d1.title, d2.title)
         eq_(crumbs, doc('nav.crumbs').text())
 
     def test_english_document_no_approved_content(self):
@@ -251,9 +251,9 @@ class RevisionTests(UserTestCase, WikiTestCase):
         response = self.client.get(url)
         eq_(200, response.status_code)
         doc = pq(response.content)
-        eq_('Revision id: %s' % r.id,
+        eq_('Revision id: {0!s}'.format(r.id),
             doc('div.revision-info li.revision-id').text())
-        eq_('Revision %s of %s' % (r.id, d.title), doc('h1').text())
+        eq_('Revision {0!s} of {1!s}'.format(r.id, d.title), doc('h1').text())
         eq_(r.content,
             doc('#doc-source pre').text())
         eq_('Created: Jan 1, 2011, 12:00:00 AM',
@@ -320,7 +320,7 @@ class NewDocumentTests(UserTestCase, WikiTestCase):
         response = self.client.post(reverse('wiki.create'), data,
                                     follow=True)
         d = Document.objects.get(title=data['title'])
-        eq_([('http://testserver/en-US/docs/%s' % d.slug, 302)],
+        eq_([('http://testserver/en-US/docs/{0!s}'.format(d.slug), 302)],
             response.redirect_chain)
         eq_(settings.WIKI_DEFAULT_LANGUAGE, d.locale)
         eq_(tags, sorted(t.name for t in d.tags.all()))
@@ -390,7 +390,7 @@ class NewDocumentTests(UserTestCase, WikiTestCase):
         d = _create_document()
         self.client.login(username='admin', password='testpass')
         data = new_document_data()
-        data['slug'] = '%s-once-more-with-feeling' % d.slug
+        data['slug'] = '{0!s}-once-more-with-feeling'.format(d.slug)
         response = self.client.post(reverse('wiki.create'), data)
         eq_(302, response.status_code)
 
@@ -492,20 +492,20 @@ class NewRevisionTests(UserTestCase, WikiTestCase):
         eq_(2, len(mail.outbox))
         first_edit_email = mail.outbox[0]
         expected_to = [config.EMAIL_LIST_FOR_FIRST_EDITS]
-        expected_subject = u'[MDN] %(username)s made their first edit, to: %(title)s' % ({'username': new_rev.creator.username, 'title': self.d.title})
+        expected_subject = u'[MDN] {username!s} made their first edit, to: {title!s}'.format(**({'username': new_rev.creator.username, 'title': self.d.title}))
         eq_(expected_subject, first_edit_email.subject)
         eq_(expected_to, first_edit_email.to)
 
         edited_email = mail.outbox[1]
         expected_to = [u'sam@example.com']
-        expected_subject = u'[MDN] Page "%s" changed by %s' % (self.d.title,
+        expected_subject = u'[MDN] Page "{0!s}" changed by {1!s}'.format(self.d.title,
                                                                new_rev.creator)
         eq_(expected_subject, edited_email.subject)
         eq_(expected_to, edited_email.to)
-        ok_('%s changed %s.' % (unicode(self.username), unicode(self.d.title))
+        ok_('{0!s} changed {1!s}.'.format(unicode(self.username), unicode(self.d.title))
             in edited_email.body)
-        ok_(u'https://testserver/en-US/docs/%s$history?utm_campaign=' %
-            self.d.slug
+        ok_(u'https://testserver/en-US/docs/{0!s}$history?utm_campaign='.format(
+            self.d.slug)
             in edited_email.body)
 
     @mock.patch.object(EditDocumentEvent, 'fire')
@@ -783,7 +783,7 @@ class TranslateTests(UserTestCase, WikiTestCase):
         translate_uri = reverse('wiki.translate',
                                 locale='en-US',
                                 args=[self.d.slug])
-        return '%s?tolocale=%s' % (translate_uri, 'es')
+        return '{0!s}?tolocale={1!s}'.format(translate_uri, 'es')
 
     def test_translate_GET_logged_out(self):
         """Try to create a translation while logged out."""
@@ -791,7 +791,7 @@ class TranslateTests(UserTestCase, WikiTestCase):
         translate_uri = self._translate_uri()
         response = self.client.get(translate_uri)
         eq_(302, response.status_code)
-        expected_url = '%s?next=%s' % (reverse('account_login', locale='en-US'),
+        expected_url = '{0!s}?next={1!s}'.format(reverse('account_login', locale='en-US'),
                                        urlquote(translate_uri))
         ok_(expected_url in response['Location'])
 

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -73,8 +73,8 @@ class RedirectTests(UserTestCase, WikiTestCase):
     def test_self_redirect_suppression(self):
         """The document view shouldn't redirect to itself."""
         slug = 'redirdoc'
-        html = ('REDIRECT <a class="redirect" href="/en-US/docs/%s">smoo</a>' %
-                slug)
+        html = ('REDIRECT <a class="redirect" href="/en-US/docs/{0!s}">smoo</a>'.format(
+                slug))
 
         doc = document(title='blah', slug=slug, html=html, save=True,
                        locale=settings.WIKI_DEFAULT_LANGUAGE)
@@ -114,13 +114,13 @@ class LocaleRedirectTests(UserTestCase, WikiTestCase):
     def test_redirect_with_no_slug(self):
         """Bug 775241: Fix exception in redirect for URL with ui-locale"""
         loc = settings.WIKI_DEFAULT_LANGUAGE
-        url = '/%s/docs/%s/' % (loc, loc)
+        url = '/{0!s}/docs/{1!s}/'.format(loc, loc)
         try:
             self.client.get(url, follow=True)
         except Http404, e:
             pass
         except Exception as e:
-            self.fail("The only exception should be a 404, not this: %s" % e)
+            self.fail("The only exception should be a 404, not this: {0!s}".format(e))
 
     def _create_en_and_de_docs(self):
         en = settings.WIKI_DEFAULT_LANGUAGE
@@ -183,7 +183,7 @@ class ViewTests(UserTestCase, WikiTestCase):
 
         for i in xrange(1, 51):
             revision(document=doc, content=html,
-                     comment='Revision %s' % i,
+                     comment='Revision {0!s}'.format(i),
                      is_approved=True, save=True)
 
         url = reverse('wiki.document_revisions', args=(slug,),
@@ -264,7 +264,7 @@ class ViewTests(UserTestCase, WikiTestCase):
             url = reverse('wiki.children', args=['Root'],
                           locale=settings.WIKI_DEFAULT_LANGUAGE)
             if expand:
-                url = '%s?expand' % url
+                url = '{0!s}?expand'.format(url)
             resp = self.client.get(url)
             ok_('Access-Control-Allow-Origin' in resp)
             eq_('*', resp['Access-Control-Allow-Origin'])
@@ -318,7 +318,7 @@ class ViewTests(UserTestCase, WikiTestCase):
             <p>Foo bar <a href="http://example.com">baz</a></p>
             <p>Quux xyzzy</p>
         """)
-        resp = self.client.get('%s?raw&summary' % d.get_absolute_url())
+        resp = self.client.get('{0!s}?raw&summary'.format(d.get_absolute_url()))
         eq_(resp.content, 'Foo bar <a href="http://example.com">baz</a>')
 
     @mock.patch('waffle.flag_is_active', return_value=True)
@@ -392,8 +392,8 @@ class ViewTests(UserTestCase, WikiTestCase):
                     display:block;
                 }
             """)
-        response = self.client.get('%s?raw=true' %
-                                   reverse('wiki.document', args=[doc.slug]))
+        response = self.client.get('{0!s}?raw=true'.format(
+                                   reverse('wiki.document', args=[doc.slug])))
         ok_('text/css' in response['Content-Type'])
 
 
@@ -482,13 +482,11 @@ class PermissionTests(UserTestCase, WikiTestCase):
 
                     if expected:
                         eq_(302, resp.status_code,
-                            "%s should be able to %s %s" %
-                            (user, msg[is_add], slug))
+                            "{0!s} should be able to {1!s} {2!s}".format(user, msg[is_add], slug))
                         Document.objects.filter(slug=slug).delete()
                     else:
                         eq_(403, resp.status_code,
-                            "%s should not be able to %s %s" %
-                            (user, msg[is_add], slug))
+                            "{0!s} should not be able to {1!s} {2!s}".format(user, msg[is_add], slug))
 
 
 class ConditionalGetTests(UserTestCase, WikiTestCase):
@@ -742,21 +740,21 @@ class KumascriptIntegrationTests(UserTestCase, WikiTestCase):
     @override_config(KUMASCRIPT_TIMEOUT=1.0)
     @mock.patch('kuma.wiki.kumascript.get', return_value=(TEST_CONTENT, None))
     def test_nomacros(self, mock_kumascript_get):
-        self.client.get('%s?nomacros' % self.url, follow=False)
+        self.client.get('{0!s}?nomacros'.format(self.url), follow=False)
         ok_(not mock_kumascript_get.called,
             "kumascript should not have been used")
 
     @override_config(KUMASCRIPT_TIMEOUT=1.0)
     @mock.patch('kuma.wiki.kumascript.get', return_value=(TEST_CONTENT, None))
     def test_raw(self, mock_kumascript_get):
-        self.client.get('%s?raw' % self.url, follow=False)
+        self.client.get('{0!s}?raw'.format(self.url), follow=False)
         ok_(not mock_kumascript_get.called,
             "kumascript should not have been used")
 
     @override_config(KUMASCRIPT_TIMEOUT=1.0)
     @mock.patch('kuma.wiki.kumascript.get', return_value=(TEST_CONTENT, None))
     def test_raw_macros(self, mock_kumascript_get):
-        self.client.get('%s?raw&macros' % self.url, follow=False)
+        self.client.get('{0!s}?raw&macros'.format(self.url), follow=False)
         ok_(mock_kumascript_get.called, "kumascript should have been used")
 
     @override_config(KUMASCRIPT_TIMEOUT=1.0, KUMASCRIPT_MAX_AGE=1234)
@@ -904,7 +902,7 @@ class KumascriptIntegrationTests(UserTestCase, WikiTestCase):
         fl_uid = 8675309
         headers_out = {}
         for i in range(0, len(d_lines)):
-            headers_out['%s-%s-%s' % (p[i % len(p)], fl_uid, i)] = d_lines[i]
+            headers_out['{0!s}-{1!s}-{2!s}'.format(p[i % len(p)], fl_uid, i)] = d_lines[i]
 
         mock_requests.get(
             requests_mock.ANY,
@@ -1091,7 +1089,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         args = [r.document.slug]
         urls = (
             reverse('wiki.edit', args=args),
-            '%s?tolocale=%s' % (reverse('wiki.translate', args=args), 'fr')
+            '{0!s}?tolocale={1!s}'.format(reverse('wiki.translate', args=args), 'fr')
         )
         for url in urls:
             page = pq(self.client.get(url).content)
@@ -1107,7 +1105,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         # Establish attribs of child page.
         locale = settings.WIKI_DEFAULT_LANGUAGE
         local_slug = 'Some_New_Title'
-        slug = '%s/%s' % (d.slug, local_slug)
+        slug = '{0!s}/{1!s}'.format(d.slug, local_slug)
         url = reverse('wiki.document', args=[slug], locale=locale)
 
         # Ensure redirect to create new page on attempt to visit non-existent
@@ -1115,12 +1113,12 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         resp = self.client.get(url)
         eq_(302, resp.status_code)
         ok_('docs/new' in resp['Location'])
-        ok_('?slug=%s' % local_slug in resp['Location'])
+        ok_('?slug={0!s}'.format(local_slug) in resp['Location'])
 
         # Ensure real 404 for visit to non-existent page with params common to
         # kumascript and raw content API.
         for p_name in ('raw', 'include', 'nocreate'):
-            sub_url = '%s?%s=1' % (url, p_name)
+            sub_url = '{0!s}?{1!s}=1'.format(url, p_name)
             resp = self.client.get(sub_url)
             eq_(404, resp.status_code)
 
@@ -1242,8 +1240,8 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         data.update({'title': d.title,
                      'slug': new_slug,
                      'form': 'rev'})
-        self.client.post('%s?iframe=1' % reverse('wiki.edit',
-                                                 args=[d.slug]), data)
+        self.client.post('{0!s}?iframe=1'.format(reverse('wiki.edit',
+                                                 args=[d.slug])), data)
         eq_(old_slug, Document.objects.get(slug=d.slug,
                                            locale=d.locale).slug)
         assert "REDIRECT" not in Document.objects.get(slug=old_slug).html
@@ -1340,7 +1338,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
             'in valid',  # whitespace
         ]
         for invalid_slug in invalid_slugs:
-            data['title'] = 'invalid with %s' % invalid_slug
+            data['title'] = 'invalid with {0!s}'.format(invalid_slug)
             data['slug'] = invalid_slug
             response = self.client.post(new_url, data)
             self.assertContains(response, 'The slug provided is not valid.')
@@ -1371,7 +1369,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         )
 
         for term in reserved_slugs:
-            data['title'] = 'invalid with %s' % term
+            data['title'] = 'invalid with {0!s}'.format(term)
             data['slug'] = term
             response = self.client.post(reverse('wiki.create'), data)
             self.assertContains(response, 'The slug provided is not valid.')
@@ -2030,11 +2028,11 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
                                                args=[doc.slug]), data)
             page = pq(response.content)
             for t in yes_tags:
-                eq_(1, page.find('.tags li a:contains("%s")' % t).length,
-                    '%s should NOT appear in document view tags' % t)
+                eq_(1, page.find('.tags li a:contains("{0!s}")'.format(t)).length,
+                    '{0!s} should NOT appear in document view tags'.format(t))
             for t in no_tags:
-                eq_(0, page.find('.tags li a:contains("%s")' % t).length,
-                    '%s should appear in document view tags' % t)
+                eq_(0, page.find('.tags li a:contains("{0!s}")'.format(t)).length,
+                    '{0!s} should appear in document view tags'.format(t))
 
             # Check for the document slug (title in feeds) in the tag listing
             for t in yes_tags:
@@ -2105,28 +2103,28 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
 
         # Ensure the page appears on the listing pages
         response = self.client.get(reverse('wiki.list_review'))
-        eq_(1, pq(response.content).find("ul.document-list li a:contains('%s')" %
-                                         doc.title).length)
+        eq_(1, pq(response.content).find("ul.document-list li a:contains('{0!s}')".format(
+                                         doc.title)).length)
         response = self.client.get(reverse('wiki.list_review_tag',
                                            args=('technical',)))
-        eq_(1, pq(response.content).find("ul.document-list li a:contains('%s')" %
-                                         doc.title).length)
+        eq_(1, pq(response.content).find("ul.document-list li a:contains('{0!s}')".format(
+                                         doc.title)).length)
         response = self.client.get(reverse('wiki.list_review_tag',
                                            args=('editorial',)))
-        eq_(1, pq(response.content).find("ul.document-list li a:contains('%s')" %
-                                         doc.title).length)
+        eq_(1, pq(response.content).find("ul.document-list li a:contains('{0!s}')".format(
+                                         doc.title)).length)
 
         # Also, ensure that the page appears in the proper feeds
         # HACK: Too lazy to parse the XML. Lazy lazy.
         response = self.client.get(reverse('wiki.feeds.list_review',
                                            args=('atom',)))
-        ok_('<entry><title>%s</title>' % doc.title in response.content)
+        ok_('<entry><title>{0!s}</title>'.format(doc.title) in response.content)
         response = self.client.get(reverse('wiki.feeds.list_review_tag',
                                            args=('atom', 'technical', )))
-        ok_('<entry><title>%s</title>' % doc.title in response.content)
+        ok_('<entry><title>{0!s}</title>'.format(doc.title) in response.content)
         response = self.client.get(reverse('wiki.feeds.list_review_tag',
                                            args=('atom', 'editorial', )))
-        ok_('<entry><title>%s</title>' % doc.title in response.content)
+        ok_('<entry><title>{0!s}</title>'.format(doc.title) in response.content)
 
         # Post an edit that removes one of the tags.
         data.update({
@@ -2144,28 +2142,28 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
 
         # Ensure the page appears on the listing pages
         response = self.client.get(reverse('wiki.list_review'))
-        eq_(1, pq(response.content).find("ul.document-list li a:contains('%s')" %
-                                         doc.title).length)
+        eq_(1, pq(response.content).find("ul.document-list li a:contains('{0!s}')".format(
+                                         doc.title)).length)
         response = self.client.get(reverse('wiki.list_review_tag',
                                            args=('technical',)))
-        eq_(0, pq(response.content).find("ul.document-list li a:contains('%s')" %
-                                         doc.title).length)
+        eq_(0, pq(response.content).find("ul.document-list li a:contains('{0!s}')".format(
+                                         doc.title)).length)
         response = self.client.get(reverse('wiki.list_review_tag',
                                            args=('editorial',)))
-        eq_(1, pq(response.content).find("ul.document-list li a:contains('%s')" %
-                                         doc.title).length)
+        eq_(1, pq(response.content).find("ul.document-list li a:contains('{0!s}')".format(
+                                         doc.title)).length)
 
         # Also, ensure that the page appears in the proper feeds
         # HACK: Too lazy to parse the XML. Lazy lazy.
         response = self.client.get(reverse('wiki.feeds.list_review',
                                            args=('atom',)))
-        ok_('<entry><title>%s</title>' % doc.title in response.content)
+        ok_('<entry><title>{0!s}</title>'.format(doc.title) in response.content)
         response = self.client.get(reverse('wiki.feeds.list_review_tag',
                                            args=('atom', 'technical', )))
-        ok_('<entry><title>%s</title>' % doc.title not in response.content)
+        ok_('<entry><title>{0!s}</title>'.format(doc.title) not in response.content)
         response = self.client.get(reverse('wiki.feeds.list_review_tag',
                                            args=('atom', 'editorial', )))
-        ok_('<entry><title>%s</title>' % doc.title in response.content)
+        ok_('<entry><title>{0!s}</title>'.format(doc.title) in response.content)
 
     @pytest.mark.review_tags
     def test_quick_review(self):
@@ -2200,7 +2198,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         ]
 
         for data_dict in test_data:
-            slug = 'test-quick-review-%s' % data_dict['name']
+            slug = 'test-quick-review-{0!s}'.format(data_dict['name'])
             data = new_document_data()
             data.update({'review_tags': ['editorial', 'technical'],
                          'slug': slug})
@@ -2548,8 +2546,8 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         eq_(2, len(mail.outbox))
 
         def _check_message_for_headers(message, username):
-            ok_("%s made their first edit" % username in message.subject)
-            eq_({'X-Kuma-Document-Url': "https://dev.mo.org%s" % doc.get_absolute_url(),
+            ok_("{0!s} made their first edit".format(username) in message.subject)
+            eq_({'X-Kuma-Document-Url': "https://dev.mo.org{0!s}".format(doc.get_absolute_url()),
                  'X-Kuma-Editor-Username': username}, message.extra_headers)
 
         testuser_message = mail.outbox[0]
@@ -2776,8 +2774,8 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
             <p>test</p>
         """
         Switch.objects.create(name='application_ACAO', active=True)
-        response = self.client.get('%s?raw=true' %
-                                   reverse('wiki.document', args=[d.slug]),
+        response = self.client.get('{0!s}?raw=true'.format(
+                                   reverse('wiki.document', args=[d.slug])),
                                    HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         ok_('Access-Control-Allow-Origin' in response)
         eq_('*', response['Access-Control-Allow-Origin'])
@@ -2794,8 +2792,8 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
             <p onload=alert(3)>FOO</p>
             <svg><circle onload=confirm(3)>HI THERE</circle></svg>
         """)
-        response = self.client.get('%s?raw=true' %
-                                   reverse('wiki.document', args=[d.slug]),
+        response = self.client.get('{0!s}?raw=true'.format(
+                                   reverse('wiki.document', args=[d.slug])),
                                    HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         ok_('<p onload=' not in response.content)
         ok_('<circle onload=' not in response.content)
@@ -2818,18 +2816,18 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
             <p>test</p>
         """)
         expected = """
-            <h1 id="s1"><a class="edit-section" data-section-id="s1" data-section-src-url="/en-US/docs/%(slug)s?raw=true&amp;section=s1" href="/en-US/docs/%(slug)s$edit?section=s1&amp;edit_links=true" title="Edit section">Edit</a>s1</h1>
+            <h1 id="s1"><a class="edit-section" data-section-id="s1" data-section-src-url="/en-US/docs/{slug!s}?raw=true&amp;section=s1" href="/en-US/docs/{slug!s}$edit?section=s1&amp;edit_links=true" title="Edit section">Edit</a>s1</h1>
             <p>test</p>
             <p>test</p>
-            <h1 id="s2"><a class="edit-section" data-section-id="s2" data-section-src-url="/en-US/docs/%(slug)s?raw=true&amp;section=s2" href="/en-US/docs/%(slug)s$edit?section=s2&amp;edit_links=true" title="Edit section">Edit</a>s2</h1>
+            <h1 id="s2"><a class="edit-section" data-section-id="s2" data-section-src-url="/en-US/docs/{slug!s}?raw=true&amp;section=s2" href="/en-US/docs/{slug!s}$edit?section=s2&amp;edit_links=true" title="Edit section">Edit</a>s2</h1>
             <p>test</p>
             <p>test</p>
-            <h1 id="s3"><a class="edit-section" data-section-id="s3" data-section-src-url="/en-US/docs/%(slug)s?raw=true&amp;section=s3" href="/en-US/docs/%(slug)s$edit?section=s3&amp;edit_links=true" title="Edit section">Edit</a>s3</h1>
+            <h1 id="s3"><a class="edit-section" data-section-id="s3" data-section-src-url="/en-US/docs/{slug!s}?raw=true&amp;section=s3" href="/en-US/docs/{slug!s}$edit?section=s3&amp;edit_links=true" title="Edit section">Edit</a>s3</h1>
             <p>test</p>
             <p>test</p>
-        """ % {'slug': d.slug}
-        response = self.client.get('%s?raw=true&edit_links=true' %
-                                   reverse('wiki.document', args=[d.slug]),
+        """.format(**{'slug': d.slug})
+        response = self.client.get('{0!s}?raw=true&edit_links=true'.format(
+                                   reverse('wiki.document', args=[d.slug])),
                                    HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         eq_(normalize_html(expected),
             normalize_html(response.content))
@@ -2855,9 +2853,9 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
             <p>test</p>
             <p>test</p>
         """
-        response = self.client.get('%s?section=s2&raw=true' %
+        response = self.client.get('{0!s}?section=s2&raw=true'.format(
                                    reverse('wiki.document',
-                                           args=[d.slug]),
+                                           args=[d.slug])),
                                    HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         eq_(normalize_html(expected),
             normalize_html(response.content))
@@ -2886,9 +2884,9 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
             <h1 id="s2">s2</h1>
             <p>replace</p>
         """
-        response = self.client.post('%s?section=s2&raw=true' %
+        response = self.client.post('{0!s}?section=s2&raw=true'.format(
                                     reverse('wiki.edit',
-                                            args=[d.slug]),
+                                            args=[d.slug])),
                                     {"form": "rev",
                                      "slug": d.slug,
                                      "content": replace},
@@ -2909,9 +2907,9 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
             <p>test</p>
             <p>test</p>
         """
-        response = self.client.get('%s?raw=true' %
+        response = self.client.get('{0!s}?raw=true'.format(
                                    reverse('wiki.document',
-                                           args=[d.slug]),
+                                           args=[d.slug])),
                                    HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         eq_(normalize_html(expected),
             normalize_html(response.content))
@@ -2962,17 +2960,17 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
         }
 
         # Edit #1 starts...
-        resp = self.client.get('%s?section=s1' %
+        resp = self.client.get('{0!s}?section=s1'.format(
                                reverse('wiki.edit',
-                                       args=[doc.slug]),
+                                       args=[doc.slug])),
                                HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         page = pq(resp.content)
         rev_id1 = page.find('input[name="current_rev"]').attr('value')
 
         # Edit #2 starts...
-        resp = self.client.get('%s?section=s2' %
+        resp = self.client.get('{0!s}?section=s2'.format(
                                reverse('wiki.edit',
-                                       args=[doc.slug]),
+                                       args=[doc.slug])),
                                HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         page = pq(resp.content)
         rev_id2 = page.find('input[name="current_rev"]').attr('value')
@@ -2984,9 +2982,9 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
             'current_rev': rev_id2,
             'slug': doc.slug
         })
-        resp = self.client.post('%s?section=s2&raw=true' %
+        resp = self.client.post('{0!s}?section=s2&raw=true'.format(
                                 reverse('wiki.edit',
-                                        args=[doc.slug]),
+                                        args=[doc.slug])),
                                 data,
                                 HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         eq_(302, resp.status_code)
@@ -2998,8 +2996,8 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
             'content': replace_1,
             'current_rev': rev_id1
         })
-        resp = self.client.post('%s?section=s1&raw=true' %
-                                reverse('wiki.edit', args=[doc.slug]),
+        resp = self.client.post('{0!s}?section=s1&raw=true'.format(
+                                reverse('wiki.edit', args=[doc.slug])),
                                 data,
                                 HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         # No conflict, but we should get a 205 Reset as an indication that the
@@ -3007,9 +3005,9 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
         eq_(205, resp.status_code)
 
         # Finally, make sure that all the edits landed
-        response = self.client.get('%s?raw=true' %
+        response = self.client.get('{0!s}?raw=true'.format(
                                    reverse('wiki.document',
-                                           args=[doc.slug]),
+                                           args=[doc.slug])),
                                    HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         eq_(normalize_html(expected),
             normalize_html(response.content))
@@ -3052,17 +3050,17 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
         }
 
         # Edit #1 starts...
-        resp = self.client.get('%s?section=s2' %
+        resp = self.client.get('{0!s}?section=s2'.format(
                                reverse('wiki.edit',
-                                       args=[doc.slug]),
+                                       args=[doc.slug])),
                                HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         page = pq(resp.content)
         rev_id1 = page.find('input[name="current_rev"]').attr('value')
 
         # Edit #2 starts...
-        resp = self.client.get('%s?section=s2' %
+        resp = self.client.get('{0!s}?section=s2'.format(
                                reverse('wiki.edit',
-                                       args=[doc.slug]),
+                                       args=[doc.slug])),
                                HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         page = pq(resp.content)
         rev_id2 = page.find('input[name="current_rev"]').attr('value')
@@ -3074,9 +3072,9 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
             'slug': doc.slug,
             'current_rev': rev_id2
         })
-        resp = self.client.post('%s?section=s2&raw=true' %
+        resp = self.client.post('{0!s}?section=s2&raw=true'.format(
                                 reverse('wiki.edit',
-                                        args=[doc.slug]),
+                                        args=[doc.slug])),
                                 data, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         eq_(302, resp.status_code)
 
@@ -3086,9 +3084,9 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
             'content': replace_1,
             'current_rev': rev_id1
         })
-        resp = self.client.post('%s?section=s2&raw=true' %
+        resp = self.client.post('{0!s}?section=s2&raw=true'.format(
                                 reverse('wiki.edit',
-                                        args=[doc.slug]),
+                                        args=[doc.slug])),
                                 data, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         # With the raw API, we should get a 409 Conflict on collision.
         eq_(409, resp.status_code)
@@ -3113,8 +3111,8 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
               <dd>Przykłady 例 예제 示例</dd>
             </dl>
         """
-        resp = self.client.get('%s?raw&include' %
-                               reverse('wiki.document', args=[doc.slug]),
+        resp = self.client.get('{0!s}?raw&include'.format(
+                               reverse('wiki.document', args=[doc.slug])),
                                HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         eq_(normalize_html(expected),
             normalize_html(resp.content.decode('utf-8')))
@@ -3143,8 +3141,8 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
         <h1 id="s2">s2</h1>
         <p>replace</p>
         """
-        self.client.post('%s?section=s2&raw=true' %
-                         reverse('wiki.edit', args=[doc.slug]),
+        self.client.post('{0!s}?section=s2&raw=true'.format(
+                         reverse('wiki.edit', args=[doc.slug])),
                          {"form": "rev", "slug": doc.slug, "content": replace},
                          follow=True, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         changed = Document.objects.get(pk=doc.id).current_revision
@@ -3176,8 +3174,8 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
         <h1 id="s2">s2</h1>
         <p>replace</p>
         """
-        self.client.post('%s?section=s2&raw=true' %
-                         reverse('wiki.edit', args=[doc.slug]),
+        self.client.post('{0!s}?section=s2&raw=true'.format(
+                         reverse('wiki.edit', args=[doc.slug])),
                          {"form": "rev", "slug": doc.slug, "content": replace},
                          follow=True, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         changed = Document.objects.get(pk=doc.id).current_revision
@@ -3202,25 +3200,25 @@ class MindTouchRedirectTests(UserTestCase, WikiTestCase):
     # URL we constructed is enough for the document views to go on.
     localizing_client = True
 
-    server_prefix = 'http://testserver/%s/docs' % settings.WIKI_DEFAULT_LANGUAGE
+    server_prefix = 'http://testserver/{0!s}/docs'.format(settings.WIKI_DEFAULT_LANGUAGE)
     namespace_urls = (
         # One for each namespace.
         {'mindtouch': '/Help:Foo',
-         'kuma': '%s/Help:Foo' % server_prefix},
+         'kuma': '{0!s}/Help:Foo'.format(server_prefix)},
         {'mindtouch': '/Help_talk:Foo',
-         'kuma': '%s/Help_talk:Foo' % server_prefix},
+         'kuma': '{0!s}/Help_talk:Foo'.format(server_prefix)},
         {'mindtouch': '/Project:En/MDC_editor_guide',
-         'kuma': '%s/Project:MDC_editor_guide' % server_prefix},
+         'kuma': '{0!s}/Project:MDC_editor_guide'.format(server_prefix)},
         {'mindtouch': '/Project_talk:En/MDC_style_guide',
-         'kuma': '%s/Project_talk:MDC_style_guide' % server_prefix},
+         'kuma': '{0!s}/Project_talk:MDC_style_guide'.format(server_prefix)},
         {'mindtouch': '/Special:Foo',
-         'kuma': '%s/Special:Foo' % server_prefix},
+         'kuma': '{0!s}/Special:Foo'.format(server_prefix)},
         {'mindtouch': '/Talk:en/Foo',
-         'kuma': '%s/Talk:Foo' % server_prefix},
+         'kuma': '{0!s}/Talk:Foo'.format(server_prefix)},
         {'mindtouch': '/Template:Foo',
-         'kuma': '%s/Template:Foo' % server_prefix},
+         'kuma': '{0!s}/Template:Foo'.format(server_prefix)},
         {'mindtouch': '/User:Foo',
-         'kuma': '%s/User:Foo' % server_prefix},
+         'kuma': '{0!s}/User:Foo'.format(server_prefix)},
     )
 
     documents = (
@@ -3250,10 +3248,10 @@ class MindTouchRedirectTests(UserTestCase, WikiTestCase):
         d.slug = 'foofoo'
         d.title = 'FooFoo'
         d.save()
-        mt_url = '/cn/%s/' % (d.slug,)
+        mt_url = '/cn/{0!s}/'.format(d.slug)
         resp = self.client.get(mt_url)
         eq_(301, resp.status_code)
-        eq_('http://testserver%s' % d.get_absolute_url(), resp['Location'])
+        eq_('http://testserver{0!s}'.format(d.get_absolute_url()), resp['Location'])
 
     def test_document_urls(self):
         for doc in self.documents:
@@ -3262,10 +3260,10 @@ class MindTouchRedirectTests(UserTestCase, WikiTestCase):
             d.slug = doc['title']
             d.locale = doc['kuma_locale']
             d.save()
-            mt_url = '/%s' % '/'.join([doc['mt_locale'], doc['title']])
+            mt_url = '/{0!s}'.format('/'.join([doc['mt_locale'], doc['title']]))
             resp = self.client.get(mt_url)
             eq_(301, resp.status_code)
-            eq_('http://testserver%s' % doc['expected'], resp['Location'])
+            eq_('http://testserver{0!s}'.format(doc['expected']), resp['Location'])
 
     def test_view_param(self):
         d = document()
@@ -3273,10 +3271,10 @@ class MindTouchRedirectTests(UserTestCase, WikiTestCase):
         d.slug = 'HTML/HTML5'
         d.title = 'HTML 5'
         d.save()
-        mt_url = '/en-US/%s?view=edit' % (d.slug,)
+        mt_url = '/en-US/{0!s}?view=edit'.format(d.slug)
         resp = self.client.get(mt_url)
         eq_(301, resp.status_code)
-        expected_url = 'http://testserver%s$edit' % d.get_absolute_url()
+        expected_url = 'http://testserver{0!s}$edit'.format(d.get_absolute_url())
         eq_(expected_url, resp['Location'])
 
 
@@ -3346,7 +3344,7 @@ class AutosuggestDocumentsTests(WikiTestCase):
             {
                 'title': 'Something Redirect 8',
                 'slug': 'xx',
-                'html': 'REDIRECT <a class="redirect" href="%s">yo</a>' % settings.SITE_URL
+                'html': 'REDIRECT <a class="redirect" href="{0!s}">yo</a>'.format(settings.SITE_URL)
             },
             {
                 'title': 'My Template',
@@ -3429,21 +3427,20 @@ class CodeSampleViewTests(UserTestCase, WikiTestCase):
         KUMA_WIKI_IFRAME_ALLOWED_HOSTS='^https?\:\/\/sampleserver')
     def test_code_sample_iframe_embed(self):
         slug = 'test-code-embed'
-        embed_url = ('https://sampleserver/%s/docs/%s$samples/sample1' %
-                     (settings.WIKI_DEFAULT_LANGUAGE, slug))
+        embed_url = ('https://sampleserver/{0!s}/docs/{1!s}$samples/sample1'.format(settings.WIKI_DEFAULT_LANGUAGE, slug))
 
         doc_src = """
             <p>This is a page. Deal with it.</p>
             <div id="sample1" class="code-sample">
                 <pre class="brush: html">Some HTML</pre>
-                <pre class="brush: css">.some-css { color: red; }</pre>
+                <pre class="brush: css">.some-css {{ color: red; }}</pre>
                 <pre class="brush: js">window.alert("HI THERE")</pre>
             </div>
-            <iframe id="if1" src="%(embed_url)s"></iframe>
+            <iframe id="if1" src="{embed_url!s}"></iframe>
             <iframe id="if2" src="http://testserver"></iframe>
             <iframe id="if3" src="https://some.alien.site.com"></iframe>
             <p>test</p>
-        """ % dict(embed_url=embed_url)
+        """.format(**dict(embed_url=embed_url))
 
         slug = 'test-code-doc'
         d, r = doc_rev()
@@ -3491,19 +3488,19 @@ class CodeSampleViewFileServingTests(UserTestCase, WikiTestCase):
         # then build the document and revision we need to test
         attachment = Attachment.objects.get(title='An uploaded file')
         filename = attachment.current_revision.filename()
-        url_css = 'url("files/%(attachment_id)s/%(filename)s")' % {
+        url_css = 'url("files/{attachment_id!s}/{filename!s}")'.format(**{
             'attachment_id': attachment.id,
             'filename': filename,
-        }
+        })
         doc, rev = doc_rev("""
             <p>This is a page. Deal with it.</p>
             <div id="sample1" class="code-sample">
                 <pre class="brush: html">Some HTML</pre>
-                <pre class="brush: css">.some-css { background: %s }</pre>
+                <pre class="brush: css">.some-css {{ background: {0!s} }}</pre>
                 <pre class="brush: js">window.alert("HI THERE")</pre>
             </div>
             <p>test</p>
-        """ % url_css)
+        """.format(url_css))
 
         # then see of the code sample view has successfully found the sample
         response = self.client.get(reverse('wiki.code_sample',
@@ -3705,12 +3702,11 @@ class DeferredRenderingViewTests(UserTestCase, WikiTestCase):
             else:
                 self.client.logout()
 
-            url = '%s?raw&macros%s' % (doc.get_absolute_url(), param)
+            url = '{0!s}?raw&macros{1!s}'.format(doc.get_absolute_url(), param)
             response = self.client.get(url, follow=True)
             eq_(normalize_html(expected),
                 normalize_html(response.content),
-                "Should match? %s %s %s %s" %
-                (do_login, param, expected, response.content))
+                "Should match? {0!s} {1!s} {2!s} {3!s}".format(do_login, param, expected, response.content))
 
 
 class APITests(UserTestCase, WikiTestCase):
@@ -3733,8 +3729,8 @@ class APITests(UserTestCase, WikiTestCase):
         self.key_id = self.key.key
         self.key.save()
 
-        auth = '%s:%s' % (self.key_id, self.secret)
-        self.basic_auth = 'Basic %s' % base64.encodestring(auth)
+        auth = '{0!s}:{1!s}'.format(self.key_id, self.secret)
+        self.basic_auth = 'Basic {0!s}'.format(base64.encodestring(auth))
 
         self.d, self.r = doc_rev("""
             <h3 id="S1">Section 1</h3>
@@ -3801,7 +3797,7 @@ class APITests(UserTestCase, WikiTestCase):
             review_tags="technical",
         )
 
-        resp = self._put('%s?section=S2' % self.url, data,
+        resp = self._put('{0!s}?section=S2'.format(self.url), data,
                          HTTP_AUTHORIZATION=self.basic_auth)
         eq_(205, resp.status_code)
 
@@ -3859,7 +3855,7 @@ class APITests(UserTestCase, WikiTestCase):
         )
 
         # This first attempt should fail; the proposed parent does not exist.
-        url = '%s/nonexistent/newchild' % self.url
+        url = '{0!s}/nonexistent/newchild'.format(self.url)
         resp = self._put(url, data,
                          HTTP_AUTHORIZATION=self.basic_auth)
         eq_(404, resp.status_code)
@@ -3869,12 +3865,12 @@ class APITests(UserTestCase, WikiTestCase):
         # that API users do that themselves.
 
         # Now, fill in the parent gap...
-        p_doc = document(slug='%s/nonexistent' % self.d.slug,
+        p_doc = document(slug='{0!s}/nonexistent'.format(self.d.slug),
                          locale=settings.WIKI_DEFAULT_LANGUAGE,
                          parent_topic=self.d)
         p_doc.save()
         p_rev = revision(document=p_doc,
-                         slug='%s/nonexistent' % self.d.slug,
+                         slug='{0!s}/nonexistent'.format(self.d.slug),
                          title='I EXIST NOW', save=True)
         p_rev.save()
 
@@ -3883,7 +3879,7 @@ class APITests(UserTestCase, WikiTestCase):
                          HTTP_AUTHORIZATION=self.basic_auth)
         eq_(201, resp.status_code)
 
-        new_slug = '%s/nonexistent/newchild' % self.d.slug
+        new_slug = '{0!s}/nonexistent/newchild'.format(self.d.slug)
         new_doc = Document.objects.get(locale=settings.WIKI_DEFAULT_LANGUAGE,
                                        slug=new_slug)
         eq_(p_doc.pk, new_doc.parent_topic.pk)
@@ -3954,11 +3950,11 @@ class APITests(UserTestCase, WikiTestCase):
         html = """
             <html>
                 <head>
-                    <title>%(title)s</title>
+                    <title>{title!s}</title>
                 </head>
-                <body>%(content)s</body>
+                <body>{content!s}</body>
             </html>
-        """ % data
+        """.format(**data)
         resp = self._put(url, html, content_type='text/html',
                          HTTP_AUTHORIZATION=self.basic_auth)
         eq_(201, resp.status_code)
@@ -4169,14 +4165,14 @@ class DocumentZoneTests(UserTestCase, WikiTestCase):
 
         styles_url = reverse('wiki.styles', args=(self.root_doc.slug,),
                              locale=settings.WIKI_DEFAULT_LANGUAGE)
-        root_expected = ('<link rel="stylesheet" type="text/css" href="%s"' %
-                         styles_url)
+        root_expected = ('<link rel="stylesheet" type="text/css" href="{0!s}"'.format(
+                         styles_url))
         ok_(root_expected in response.content)
 
         styles_url = reverse('wiki.styles', args=(self.middle_doc.slug,),
                              locale=settings.WIKI_DEFAULT_LANGUAGE)
-        middle_expected = ('<link rel="stylesheet" type="text/css" href="%s"' %
-                           styles_url)
+        middle_expected = ('<link rel="stylesheet" type="text/css" href="{0!s}"'.format(
+                           styles_url))
         ok_(middle_expected in response.content)
 
 

--- a/kuma/wiki/urls.py
+++ b/kuma/wiki/urls.py
@@ -168,6 +168,6 @@ urlpatterns = [
         AttachmentsFeed(),
         name="attachments.feeds.recent_files"),
 
-    url(r'^/(?P<document_path>%s)' % DOCUMENT_PATH_RE.pattern,
+    url(r'^/(?P<document_path>{0!s})'.format(DOCUMENT_PATH_RE.pattern),
         include(document_patterns)),
 ]

--- a/kuma/wiki/views/document.py
+++ b/kuma/wiki/views/document.py
@@ -119,7 +119,7 @@ def _get_seo_parent_title(slug_dict, document_locale):
         try:
             seo_root_doc = Document.objects.get(locale=document_locale,
                                                 slug=slug_dict['seo_root'])
-            return u' - %s' % seo_root_doc.title
+            return u' - {0!s}'.format(seo_root_doc.title)
         except Document.DoesNotExist:
             pass
     return ''

--- a/kuma/wiki/views/edit.py
+++ b/kuma/wiki/views/edit.py
@@ -174,8 +174,8 @@ def edit(request, document_slug, document_locale, revision_id=None):
                         response = HttpResponse(textwrap.dedent("""
                             <span id="iframe-response"
                                   data-status="OK"
-                                  data-current-revision="%s">OK</span>
-                        """ % doc.current_revision.id))
+                                  data-current-revision="{0!s}">OK</span>
+                        """.format(doc.current_revision.id)))
                         response['X-Frame-Options'] = 'SAMEORIGIN'
                         return response
 
@@ -225,8 +225,8 @@ def edit(request, document_slug, document_locale, revision_id=None):
                         response = HttpResponse("""
                             <span id="iframe-response"
                                   data-status="OK"
-                                  data-current-revision="%s">OK</span>
-                        """ % doc.current_revision.id)
+                                  data-current-revision="{0!s}">OK</span>
+                        """.format(doc.current_revision.id))
                         response['X-Frame-Options'] = 'SAMEORIGIN'
                         return response
 
@@ -260,11 +260,11 @@ def edit(request, document_slug, document_locale, revision_id=None):
                             # content API, constrain to that section.
                             params['section'] = section_id
                     if params:
-                        url = '%s?%s' % (url, urlencode(params))
+                        url = '{0!s}?{1!s}'.format(url, urlencode(params))
                     if not is_raw and section_id:
                         # If a section was edited, jump to the section anchor
                         # if we're not getting raw content.
-                        url = '%s#%s' % (url, section_id)
+                        url = '{0!s}#{1!s}'.format(url, section_id)
 
                     return redirect(url)
 

--- a/kuma/wiki/views/legacy.py
+++ b/kuma/wiki/views/legacy.py
@@ -41,11 +41,11 @@ def mindtouch_namespace_redirect(request, namespace, slug):
         # simplifies figuring out where to send them.
         locale, _, doc_slug = slug.partition('/')
         new_locale = settings.MT_TO_KUMA_LOCALE_MAP.get(locale, 'en-US')
-        new_slug = '%s:%s' % (namespace, doc_slug)
+        new_slug = '{0!s}:{1!s}'.format(namespace, doc_slug)
     elif namespace == 'User':
         # For users, we look up the latest revision and get the locale
         # from there.
-        new_slug = '%s:%s' % (namespace, slug)
+        new_slug = '{0!s}:{1!s}'.format(namespace, slug)
         try:
             rev = (Revision.objects.filter(document__slug=new_slug)
                                    .latest('created'))
@@ -57,9 +57,9 @@ def mindtouch_namespace_redirect(request, namespace, slug):
         # Templates, etc. don't actually have a locale, so we give
         # them the default.
         new_locale = 'en-US'
-        new_slug = '%s:%s' % (namespace, slug)
+        new_slug = '{0!s}:{1!s}'.format(namespace, slug)
     if new_locale:
-        new_url = '/%s/docs/%s' % (request.LANGUAGE_CODE, new_slug)
+        new_url = '/{0!s}/docs/{1!s}'.format(request.LANGUAGE_CODE, new_slug)
     return redirect(new_url, permanent=True)
 
 
@@ -98,9 +98,9 @@ def mindtouch_to_kuma_redirect(request, path):
             # anyone trying to view the document in its locale with
             # their own UI locale will have the correct starting URL
             # anyway.
-            new_url = '/%s/docs/%s' % (new_locale, slug)
+            new_url = '/{0!s}/docs/{1!s}'.format(new_locale, slug)
             if 'view' in request.GET:
-                new_url = '%s$%s' % (new_url, request.GET['view'])
+                new_url = '{0!s}${1!s}'.format(new_url, request.GET['view'])
             return redirect(new_url, permanent=True)
 
         # Next we try looking up a Document with the possible locale
@@ -119,6 +119,6 @@ def mindtouch_to_kuma_redirect(request, path):
 
     location = doc.get_absolute_url()
     if 'view' in request.GET:
-        location = '%s$%s' % (location, request.GET['view'])
+        location = '{0!s}${1!s}'.format(location, request.GET['view'])
 
     return redirect(location, permanent=True)

--- a/kuma/wiki/views/misc.py
+++ b/kuma/wiki/views/misc.py
@@ -108,7 +108,7 @@ def load_documents(request):
                 messages.add_message(request, messages.INFO, user_msg)
             except Exception as e:
                 err_msg = (ugettext('Failed to import data: %(error)s') %
-                           {'error': '%s' % e, })
+                           {'error': '{0!s}'.format(e), })
                 messages.add_message(request, messages.ERROR, err_msg)
 
     context = {'import_file_form': form}

--- a/scripts/chief_deploy.py
+++ b/scripts/chief_deploy.py
@@ -36,7 +36,7 @@ os.environ['PATH'] = os.pathsep.join([
 def update_code(ctx, tag):
     with ctx.lcd(settings.SRC_DIR):
         ctx.local("git fetch")
-        ctx.local("git checkout -f %s" % tag)
+        ctx.local("git checkout -f {0!s}".format(tag))
         ctx.local("git submodule sync")
         ctx.local("git submodule update --init --recursive")
 
@@ -87,7 +87,7 @@ def deploy_kumascript(ctx):
 @hostgroups(settings.WEB_HOSTGROUP, remote_kwargs={'ssh_key': settings.SSH_KEY})
 def prime_app(ctx):
     for http_port in range(80, 82):
-        ctx.remote("for i in {1..10}; do curl -so /dev/null -H 'Host: %s' -I http://localhost:%s/ & sleep 1; done" % (settings.REMOTE_HOSTNAME, http_port))
+        ctx.remote("for i in {{1..10}}; do curl -so /dev/null -H 'Host: {0!s}' -I http://localhost:{1!s}/ & sleep 1; done".format(settings.REMOTE_HOSTNAME, http_port))
 
 
 @hostgroups(settings.CELERY_HOSTGROUP, remote_kwargs={'ssh_key': settings.SSH_KEY})
@@ -104,7 +104,7 @@ def ping_newrelic(ctx):
     f = open(settings.SRC_DIR + "/media/revision.txt", "r")
     tag = f.read()
     f.close()
-    ctx.local('curl --silent -H "x-api-key:%s" -d "deployment[app_name]=%s" -d "deployment[revision]=%s" -d "deployment[user]=Chief" https://rpm.newrelic.com/deployments.xml' % (settings.NEWRELIC_API_KEY, settings.REMOTE_HOSTNAME, tag))
+    ctx.local('curl --silent -H "x-api-key:{0!s}" -d "deployment[app_name]={1!s}" -d "deployment[revision]={2!s}" -d "deployment[user]=Chief" https://rpm.newrelic.com/deployments.xml'.format(settings.NEWRELIC_API_KEY, settings.REMOTE_HOSTNAME, tag))
 
 
 @task
@@ -125,22 +125,22 @@ def setup_dependencies(ctx):
         # Dearly beloved. We gather here to destroy this virtualenv in the
         # hopes that out of the ashes will rise another new and beautiful
         # virtualenv with no mistakes in it.
-        ctx.local('rm -rf %s' % settings.VENV_DIR)
-        ctx.local('virtualenv-2.7 --no-site-packages %s' % settings.VENV_DIR)
+        ctx.local('rm -rf {0!s}'.format(settings.VENV_DIR))
+        ctx.local('virtualenv-2.7 --no-site-packages {0!s}'.format(settings.VENV_DIR))
 
         # Activate virtualenv to append to the correct path to $PATH.
         activate_env = os.path.join(VENV_BIN, 'activate_this.py')
         execfile(activate_env, dict(__file__=activate_env))
 
         pip = os.path.join(VENV_BIN, 'pip')
-        ctx.local('%s install --upgrade "pip==%s"' % (pip, PIP_VERSION))
+        ctx.local('{0!s} install --upgrade "pip=={1!s}"'.format(pip, PIP_VERSION))
         ctx.local('pip --version')
-        ctx.local('%s install -r requirements/default.txt' % pip)
+        ctx.local('{0!s} install -r requirements/default.txt'.format(pip))
         # Make the virtualenv relocatable
-        ctx.local('virtualenv-2.7 --relocatable %s' % settings.VENV_DIR)
+        ctx.local('virtualenv-2.7 --relocatable {0!s}'.format(settings.VENV_DIR))
 
         # Fix lib64 symlink to be relative instead of absolute.
-        ctx.local('rm -f %s' % os.path.join(settings.VENV_DIR, 'lib64'))
+        ctx.local('rm -f {0!s}'.format(os.path.join(settings.VENV_DIR, 'lib64')))
         with ctx.lcd(settings.VENV_DIR):
             ctx.local('ln -s lib lib64')
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:kuma?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:kuma?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
